### PR TITLE
HOTT-2422: Update default variable configuration for github repo module

### DIFF
--- a/github/repos/main.tf
+++ b/github/repos/main.tf
@@ -9,6 +9,7 @@ resource "github_repository" "repo" {
 
   has_wiki               = var.has_wiki
   has_issues             = var.has_issues
+  has_projects           = var.has_projects
   has_downloads          = var.has_downloads
   allow_rebase_merge     = var.allow_rebase_merge
   allow_squash_merge     = var.allow_squash_merge

--- a/github/repos/variables.tf
+++ b/github/repos/variables.tf
@@ -44,7 +44,7 @@ variable "default_branch_name" {
 }
 
 variable "strict_status_check" {
-  default     = false
+  default     = true
   description = "Whether to require branches to be up-to-date before merging."
 }
 
@@ -75,24 +75,29 @@ variable "require_code_owner_reviews" {
   default = false
 }
 
+variable "has_projects" {
+  type    = bool
+  default = false
+}
+
 variable "has_issues" {
   type    = bool
-  default = true
+  default = false
 }
 
 variable "allow_rebase_merge" {
   type    = bool
-  default = true
+  default = false
 }
 
 variable "allow_squash_merge" {
   type    = bool
-  default = true
+  default = false
 }
 
 variable "has_downloads" {
   type    = bool
-  default = false
+  default = true
 }
 
 variable "delete_branch_on_merge" {


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2422

### What?

I have added/removed/altered:

- [x] Added has_project variable to pass to the repo module
- [x] Updated the default configuration of repos

### Why?

I am doing this because:

- The default configuration enables us to have better conventions around managing repos with less repo specific configuration. It also means we guarantee non-breaking commit histories for release notes.
- We don't use the has_project functionality so we're now disabling this by default
