### PR TITLE
HOTT-2493: Update minimum protocol version to TLSv1.2_2021

### DIFF
--- a/aws/cloudfront/main.tf
+++ b/aws/cloudfront/main.tf
@@ -138,7 +138,7 @@ resource "aws_cloudfront_distribution" "this" {
     cloudfront_default_certificate = lookup(var.viewer_certificate, "cloudfront_default_certificate", null)
     iam_certificate_id             = lookup(var.viewer_certificate, "iam_certificate_id", null)
 
-    minimum_protocol_version = lookup(var.viewer_certificate, "minimum_protocol_version", "TLSv1")
+    minimum_protocol_version = lookup(var.viewer_certificate, "minimum_protocol_version", "TLSv1.2_2021")
     ssl_support_method       = lookup(var.viewer_certificate, "ssl_support_method", null)
   }
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2493

### What?

I have added/removed/altered:

- [x] Remove now-deprecated configuration
- [x] Update minimum_protocol_version to TLSv1.2_2021

### Why?

I am doing this because:

- This is an issue identified by our recent pentest

### Out of scope

- Cloud foundry internal ssl termination already supports sensible protocol versions
