### PR TITLE
HOTT-2428: Import terragrunt bucket and user and add custom policies

### DIFF
--- a/trade-tariff/common/iam.tf
+++ b/trade-tariff/common/iam.tf
@@ -16,6 +16,15 @@ resource "aws_iam_user" "ci-account" {
   path = "/system/"
 }
 
+resource "aws_iam_access_key" "trade-tariff-bot-account" {
+  user = aws_iam_user.trade-tariff-bot-account.name
+}
+
+resource "aws_iam_user" "trade-tariff-bot-account" {
+  name = "trade-tariff-bot"
+  path = "/system/"
+}
+
 resource "aws_iam_access_key" "dit-database-backups-account" {
   user = aws_iam_user.dit-database-backups-account.name
 }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2428

### What?

I have added/removed/altered:

- [x] Import terragrunt bucket
- [x] Import bot user
- [x] Apply a restrictive bucket access policy to bot user

### Why?

I am doing this because:

- This is required to make sure that we don't have super permissive s3 access for the bot user
