### PR TITLE
HOTT-2775: Adds list-package-for-domain permission to ci user

### DIFF
--- a/trade-tariff/common/iam.tf
+++ b/trade-tariff/common/iam.tf
@@ -122,6 +122,7 @@ data "aws_iam_policy_document" "es" {
     actions = [
       "es:DescribePackages",
       "es:UpdatePackage",
+      "es:ListPackagesForDomain",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2775
https://github.com/trade-tariff/trade-tariff-backend/pull/1109

### What?

I have added/removed/altered:

- [x] Added permission to ci user to list packages for a domain

### Why?

I am doing this because:

- This is required to validate status of the new version upgrade and avoid applying associations before the previous one is available
- Because AWS haven't done basic queueing on their events
