### PR TITLE
BAU: Change default for squash and merge to true

### DIFF
--- a/github/repos/.terraform.lock.hcl
+++ b/github/repos/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/integrations/github" {
   constraints = "4.23.0"
   hashes = [
     "h1:C8mQRZrHenfru/LKN+qqwAI6aEIGbu9iWaWVmGFwcy4=",
+    "h1:eylJFdBYJIxdyyElE1mV7cMcv2HjUYzv+pFZjg/aRLU=",
     "zh:003f67dcb506ea50b34acce92f575cd04560a21c57bb63de1c9b3874dda10337",
     "zh:1b9e77fb728e3d2c8d25d04ac613e7587714c63c54532ac96787b4d351b164de",
     "zh:1d2c486c7529c832a3129c4aa38f63f20067ad0652dfdb55e5cb567a13551390",

--- a/github/repos/README.md
+++ b/github/repos/README.md
@@ -35,15 +35,16 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_teams"></a> [admin\_teams](#input\_admin\_teams) | n/a | `list` | `[]` | no |
 | <a name="input_allow_push_to_main"></a> [allow\_push\_to\_main](#input\_allow\_push\_to\_main) | n/a | `string` | `"true"` | no |
-| <a name="input_allow_rebase_merge"></a> [allow\_rebase\_merge](#input\_allow\_rebase\_merge) | n/a | `bool` | `true` | no |
+| <a name="input_allow_rebase_merge"></a> [allow\_rebase\_merge](#input\_allow\_rebase\_merge) | n/a | `bool` | `false` | no |
 | <a name="input_allow_squash_merge"></a> [allow\_squash\_merge](#input\_allow\_squash\_merge) | n/a | `bool` | `true` | no |
 | <a name="input_archived"></a> [archived](#input\_archived) | n/a | `bool` | `false` | no |
 | <a name="input_default_branch_name"></a> [default\_branch\_name](#input\_default\_branch\_name) | n/a | `string` | `"main"` | no |
 | <a name="input_delete_branch_on_merge"></a> [delete\_branch\_on\_merge](#input\_delete\_branch\_on\_merge) | n/a | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | n/a | `string` | n/a | yes |
 | <a name="input_enforce_admins"></a> [enforce\_admins](#input\_enforce\_admins) | Whether to enforce branch protection against admins e.g. no push to main, no merge without approvals | `bool` | `false` | no |
-| <a name="input_has_downloads"></a> [has\_downloads](#input\_has\_downloads) | n/a | `bool` | `false` | no |
-| <a name="input_has_issues"></a> [has\_issues](#input\_has\_issues) | n/a | `bool` | `true` | no |
+| <a name="input_has_downloads"></a> [has\_downloads](#input\_has\_downloads) | n/a | `bool` | `true` | no |
+| <a name="input_has_issues"></a> [has\_issues](#input\_has\_issues) | n/a | `bool` | `false` | no |
+| <a name="input_has_projects"></a> [has\_projects](#input\_has\_projects) | n/a | `bool` | `false` | no |
 | <a name="input_has_wiki"></a> [has\_wiki](#input\_has\_wiki) | n/a | `bool` | `false` | no |
 | <a name="input_homepage_url"></a> [homepage\_url](#input\_homepage\_url) | n/a | `string` | `""` | no |
 | <a name="input_is_template"></a> [is\_template](#input\_is\_template) | Set to true to tell GitHub that this is a template repository. | `bool` | `null` | no |
@@ -56,7 +57,7 @@ No modules.
 | <a name="input_require_signed_commits"></a> [require\_signed\_commits](#input\_require\_signed\_commits) | Whether this branch requires all commits to be signed before push or merge. | `bool` | `false` | no |
 | <a name="input_required_approving_review_count"></a> [required\_approving\_review\_count](#input\_required\_approving\_review\_count) | n/a | `number` | `2` | no |
 | <a name="input_required_status_check_contexts"></a> [required\_status\_check\_contexts](#input\_required\_status\_check\_contexts) | List of status checks which need to pass before a pull-request can be merged. | `list` | `[]` | no |
-| <a name="input_strict_status_check"></a> [strict\_status\_check](#input\_strict\_status\_check) | Whether to require branches to be up-to-date before merging. | `bool` | `false` | no |
+| <a name="input_strict_status_check"></a> [strict\_status\_check](#input\_strict\_status\_check) | Whether to require branches to be up-to-date before merging. | `bool` | `true` | no |
 | <a name="input_template"></a> [template](#input\_template) | Template repository and owner to use | `list(map(string))` | `[]` | no |
 | <a name="input_visibility"></a> [visibility](#input\_visibility) | n/a | `string` | `"private"` | no |
 | <a name="input_vulnerability_alerts"></a> [vulnerability\_alerts](#input\_vulnerability\_alerts) | GitHub vulnerability alerts | `bool` | `false` | no |

--- a/github/repos/variables.tf
+++ b/github/repos/variables.tf
@@ -92,7 +92,7 @@ variable "allow_rebase_merge" {
 
 variable "allow_squash_merge" {
   type    = bool
-  default = false
+  default = true
 }
 
 variable "has_downloads" {


### PR DESCRIPTION
### What?

I have added/removed/altered:

- [ ] Changed default for `var.allow_squash_merge` to `true`

### Why?

I am doing this because:

- On [large PRs with a large number of commits](https://github.com/trade-tariff/trade-tariff-platform-terragrunt/pull/12), I would like to be able to squash these down to a merge commit instead of adding 50~ commits to main.
