### PR TITLE
HOTT-2823: Allow squash merges

### DIFF
--- a/github/repos/variables.tf
+++ b/github/repos/variables.tf
@@ -92,7 +92,7 @@ variable "allow_rebase_merge" {
 
 variable "allow_squash_merge" {
   type    = bool
-  default = false
+  default = true
 }
 
 variable "has_downloads" {


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2823

### What?

I have added/removed/altered:

- [x] Added default support for squash merges on repos

### Why?

I am doing this because:

- This is required to enable a cleaner history
