### PR TITLE
HOTT-2885: Configure WAF provider region

### DIFF
--- a/aws/acm/terraform.tf
+++ b/aws/acm/terraform.tf
@@ -7,7 +7,7 @@ terraform {
   }
 }
 
-# Provider myst be in us-east-1 as per https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cnames-and-https-requirements.html
+# Provider must be in us-east-1 as per https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cnames-and-https-requirements.html
 provider "aws" {
   region = "us-east-1"
 }

--- a/aws/waf/main.tf
+++ b/aws/waf/main.tf
@@ -1,3 +1,8 @@
+# https://docs.aws.amazon.com/waf/latest/developerguide/how-aws-waf-works.html
+provider "aws" {
+  region = "us-east-1"
+}
+
 resource "aws_wafv2_web_acl" "this" {
   name        = var.name
   description = "WAFv2 ACL for ${var.name}"


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2885

### What?

I have added/removed/altered:

- [x] Added provider to the WAF

### Why?

I am doing this because:

- Cloudfront resources always have to be in the us-east-1 region
