### PR TITLE
BAU: Suppress etag warning by removing ignore_changes element

### DIFF
--- a/github/repos/README.md
+++ b/github/repos/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | 4.23.0 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 4.23.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | 4.23.0 |
+| <a name="provider_github"></a> [github](#provider\_github) | >= 4.23.0 |
 
 ## Modules
 
@@ -22,18 +22,18 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [github_branch_protection.repo_protect_main](https://registry.terraform.io/providers/integrations/github/4.23.0/docs/resources/branch_protection) | resource |
-| [github_repository.repo](https://registry.terraform.io/providers/integrations/github/4.23.0/docs/resources/repository) | resource |
-| [github_team_repository.repo_team_admin](https://registry.terraform.io/providers/integrations/github/4.23.0/docs/resources/team_repository) | resource |
-| [github_team_repository.repo_team_maintain](https://registry.terraform.io/providers/integrations/github/4.23.0/docs/resources/team_repository) | resource |
-| [github_team_repository.repo_team_pull](https://registry.terraform.io/providers/integrations/github/4.23.0/docs/resources/team_repository) | resource |
-| [github_team_repository.repo_team_push](https://registry.terraform.io/providers/integrations/github/4.23.0/docs/resources/team_repository) | resource |
+| [github_branch_protection.repo_protect_main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection) | resource |
+| [github_repository.repo](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
+| [github_team_repository.repo_team_admin](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
+| [github_team_repository.repo_team_maintain](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
+| [github_team_repository.repo_team_pull](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
+| [github_team_repository.repo_team_push](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_admin_teams"></a> [admin\_teams](#input\_admin\_teams) | n/a | `list` | `[]` | no |
+| <a name="input_admin_teams"></a> [admin\_teams](#input\_admin\_teams) | n/a | `list(any)` | `[]` | no |
 | <a name="input_allow_push_to_main"></a> [allow\_push\_to\_main](#input\_allow\_push\_to\_main) | n/a | `string` | `"true"` | no |
 | <a name="input_allow_rebase_merge"></a> [allow\_rebase\_merge](#input\_allow\_rebase\_merge) | n/a | `bool` | `false` | no |
 | <a name="input_allow_squash_merge"></a> [allow\_squash\_merge](#input\_allow\_squash\_merge) | n/a | `bool` | `true` | no |
@@ -48,15 +48,15 @@ No modules.
 | <a name="input_has_wiki"></a> [has\_wiki](#input\_has\_wiki) | n/a | `bool` | `false` | no |
 | <a name="input_homepage_url"></a> [homepage\_url](#input\_homepage\_url) | n/a | `string` | `""` | no |
 | <a name="input_is_template"></a> [is\_template](#input\_is\_template) | Set to true to tell GitHub that this is a template repository. | `bool` | `null` | no |
-| <a name="input_maintain_teams"></a> [maintain\_teams](#input\_maintain\_teams) | n/a | `list` | `[]` | no |
+| <a name="input_maintain_teams"></a> [maintain\_teams](#input\_maintain\_teams) | n/a | `list(any)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
 | <a name="input_pages"></a> [pages](#input\_pages) | (Optional) The repository's GitHub Pages configuration. (Default: {}) | `any` | `null` | no |
-| <a name="input_push_teams"></a> [push\_teams](#input\_push\_teams) | n/a | `list` | `[]` | no |
-| <a name="input_read_teams"></a> [read\_teams](#input\_read\_teams) | n/a | `list` | `[]` | no |
+| <a name="input_push_teams"></a> [push\_teams](#input\_push\_teams) | n/a | `list(any)` | `[]` | no |
+| <a name="input_read_teams"></a> [read\_teams](#input\_read\_teams) | n/a | `list(any)` | `[]` | no |
 | <a name="input_require_code_owner_reviews"></a> [require\_code\_owner\_reviews](#input\_require\_code\_owner\_reviews) | n/a | `bool` | `false` | no |
 | <a name="input_require_signed_commits"></a> [require\_signed\_commits](#input\_require\_signed\_commits) | Whether this branch requires all commits to be signed before push or merge. | `bool` | `false` | no |
 | <a name="input_required_approving_review_count"></a> [required\_approving\_review\_count](#input\_required\_approving\_review\_count) | n/a | `number` | `2` | no |
-| <a name="input_required_status_check_contexts"></a> [required\_status\_check\_contexts](#input\_required\_status\_check\_contexts) | List of status checks which need to pass before a pull-request can be merged. | `list` | `[]` | no |
+| <a name="input_required_status_check_contexts"></a> [required\_status\_check\_contexts](#input\_required\_status\_check\_contexts) | List of status checks which need to pass before a pull-request can be merged. | `list(any)` | `[]` | no |
 | <a name="input_strict_status_check"></a> [strict\_status\_check](#input\_strict\_status\_check) | Whether to require branches to be up-to-date before merging. | `bool` | `true` | no |
 | <a name="input_template"></a> [template](#input\_template) | Template repository and owner to use | `list(map(string))` | `[]` | no |
 | <a name="input_visibility"></a> [visibility](#input\_visibility) | n/a | `string` | `"private"` | no |

--- a/github/repos/main.tf
+++ b/github/repos/main.tf
@@ -43,53 +43,34 @@ resource "github_repository" "repo" {
 }
 
 # TODO:
-# We currently have each type of github_team_repository split out into individual resources whereas this could be dyanmically created depending on whether it's push, pull, maintain or admin.
-resource "github_team_repository" "repo_team_push" {
-  count = length(var.push_teams)
+# We currently have each type of github_team_repository split out into individual resources whereas this could be dynamically created depending on whether it's push, pull, maintain or admin.
 
+resource "github_team_repository" "repo_team_push" {
+  count      = length(var.push_teams)
   team_id    = var.push_teams[count.index]
   repository = github_repository.repo.name
   permission = var.archived == "true" ? "pull" : "push"
-
-  lifecycle {
-    ignore_changes = [etag]
-  }
 }
 
 resource "github_team_repository" "repo_team_pull" {
-  count = length(var.read_teams)
-
+  count      = length(var.read_teams)
   team_id    = var.read_teams[count.index]
   repository = github_repository.repo.name
   permission = "pull"
-
-  lifecycle {
-    ignore_changes = [etag]
-  }
-
 }
-resource "github_team_repository" "repo_team_maintain" {
-  count = length(var.maintain_teams)
 
+resource "github_team_repository" "repo_team_maintain" {
+  count      = length(var.maintain_teams)
   team_id    = var.maintain_teams[count.index]
   repository = github_repository.repo.name
   permission = "maintain"
-
-  lifecycle {
-    ignore_changes = [etag]
-  }
 }
 
 resource "github_team_repository" "repo_team_admin" {
-  count = length(var.admin_teams)
-
+  count      = length(var.admin_teams)
   team_id    = var.admin_teams[count.index]
   repository = github_repository.repo.name
   permission = "admin"
-
-  lifecycle {
-    ignore_changes = [etag]
-  }
 }
 
 resource "github_branch_protection" "repo_protect_main" {

--- a/github/repos/variables.tf
+++ b/github/repos/variables.tf
@@ -12,43 +12,52 @@ variable "homepage_url" {
 }
 
 variable "visibility" {
+  type    = string
   default = "private"
 }
 
 variable "archived" {
+  type    = bool
   default = false
 }
 
 variable "push_teams" {
+  type    = list(any)
   default = []
 }
 
 variable "read_teams" {
+  type    = list(any)
   default = []
 }
 variable "maintain_teams" {
+  type    = list(any)
   default = []
 }
 
 variable "admin_teams" {
+  type    = list(any)
   default = []
 }
 
-
 variable "allow_push_to_main" {
+  type    = string
   default = "true"
 }
 
 variable "default_branch_name" {
+  type    = string
   default = "main"
 }
 
 variable "strict_status_check" {
+  type        = bool
   default     = true
   description = "Whether to require branches to be up-to-date before merging."
 }
 
 variable "require_signed_commits" {
+  type        = bool
   default     = false
   description = "Whether this branch requires all commits to be signed before push or merge."
 }
@@ -62,16 +71,16 @@ variable "is_template" {
 variable "template" {
   description = "Template repository and owner to use"
   type        = list(map(string))
-
-  default = [
-  ]
+  default     = []
 }
 
 variable "required_approving_review_count" {
+  type    = number
   default = 2
 }
 
 variable "require_code_owner_reviews" {
+  type    = bool
   default = false
 }
 
@@ -106,21 +115,25 @@ variable "delete_branch_on_merge" {
 }
 
 variable "has_wiki" {
+  type    = bool
   default = false
 }
 
 variable "enforce_admins" {
   description = "Whether to enforce branch protection against admins e.g. no push to main, no merge without approvals"
+  type        = bool
   default     = false
 }
 
 variable "required_status_check_contexts" {
   description = "List of status checks which need to pass before a pull-request can be merged."
+  type        = list(any)
   default     = []
 }
 
 variable "vulnerability_alerts" {
   description = "GitHub vulnerability alerts"
+  type        = bool
   default     = false
 }
 

--- a/github/repos/versions.tf
+++ b/github/repos/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "4.23.0"
+      version = ">= 4.23.0"
     }
   }
 }


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Removed the `ignore_changes` argument where a value of `etag` was specified.
- Added types for variables where this was missing.

### Why?

I am doing this because:

- Terraform throws a warning with this; `etag` is decided by the provider alone and there can be no configured value to compare with.
