### PR TITLE
BAU: Fix values being provided as bools

### DIFF
--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -48,7 +48,7 @@ resource "aws_ecs_task_definition" "this" {
       image       = "${var.docker_image}:${var.docker_tag}"
       cpu         = var.cpu
       memory      = var.memory
-      essential   = true
+      essential   = "true"
       environment = local.merged_environment
       secrets     = local.merged_secrets
 
@@ -61,7 +61,7 @@ resource "aws_ecs_task_definition" "this" {
         logDriver = "awslogs"
         options = {
           awslogs-region        = var.region
-          awslogs-create-group  = true
+          awslogs-create-group  = "true"
           awslogs-stream-prefix = "ecs"
         }
       }


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Updated all `true` values to strings: `"true"`.
### Why?

I am doing this because:

- When go attempts to unmarshal these values into strings it fails, so we need to make sure we're always providing strings.