### PR TITLE
BAU: Allow extra IAM policy ARNs to be added

### DIFF
--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -29,6 +29,10 @@ No modules.
 | [aws_ecs_task_definition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_iam_role.execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.execution_role_additional_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.execution_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.task_role_additional_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.task_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
 | [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_cluster) | data source |
@@ -48,6 +52,7 @@ No modules.
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Base docker image to use. | `string` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Tag of the docker image to use. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name, i.e. `development`, `staging`, `production`. | `string` | n/a | yes |
+| <a name="input_execution_role_policy_arns"></a> [execution\_role\_policy\_arns](#input\_execution\_role\_policy\_arns) | A list of additional policy ARNs to attach to the service's execution role. | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | A maximum capacity for autoscaling. | `number` | n/a | yes |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory limits for container. | `number` | `512` | no |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | A minimum capacity for autoscaling. Defaults to 1. | `number` | `1` | no |
@@ -61,6 +66,7 @@ No modules.
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs to place the service into. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to all resources in this module. | `map(string)` | `{}` | no |
 | <a name="input_target_group_arn"></a> [target\_group\_arn](#input\_target\_group\_arn) | ARN of the load balancer target group. | `string` | n/a | yes |
+| <a name="input_task_role_policy_arns"></a> [task\_role\_policy\_arns](#input\_task\_role\_policy\_arns) | A list of additional policy ARNs to attach to the service's task role. | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 | <a name="input_wait_for_steady_state"></a> [wait\_for\_steady\_state](#input\_wait\_for\_steady\_state) | Whether to wait for the service to become stable akin to `aws ecs wait services-stable`. Defaults to true. | `bool` | `true` | no |
 
 ## Outputs

--- a/aws/ecs-service/iam.tf
+++ b/aws/ecs-service/iam.tf
@@ -12,15 +12,31 @@ data "aws_iam_policy_document" "ecs_tasks_assume_role_policy" {
 resource "aws_iam_role" "execution_role" {
   name               = "${var.service_name}-execution-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume_role_policy.json
-  managed_policy_arns = [
-    "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
-  ]
+}
+
+resource "aws_iam_role_policy_attachment" "execution_role_policy" {
+  role       = aws_iam_role.execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "execution_role_additional_policies" {
+  for_each   = toset(compact(var.execution_role_policy_arns))
+  role       = aws_iam_role.execution_role.name_prefix
+  policy_arn = each.value
 }
 
 resource "aws_iam_role" "task_role" {
   name               = "${var.service_name}-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume_role_policy.json
-  managed_policy_arns = [
-    "arn:aws:iam::aws:policy/AmazonECS_FullAccess"
-  ]
+}
+
+resource "aws_iam_role_policy_attachment" "task_role_policy" {
+  role       = aws_iam_role.task_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonECS_FullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "task_role_additional_policies" {
+  for_each   = toset(compact(var.task_role_policy_arns))
+  role       = aws_iam_role.task_role.name
+  policy_arn = each.value
 }

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -143,3 +143,14 @@ variable "cloudwatch_log_group_name" {
   type        = string
 }
 
+variable "execution_role_policy_arns" {
+  description = "A list of additional policy ARNs to attach to the service's execution role."
+  type        = list(string)
+  default     = [""]
+}
+
+variable "task_role_policy_arns" {
+  description = "A list of additional policy ARNs to attach to the service's task role."
+  type        = list(string)
+  default     = [""]
+}


### PR DESCRIPTION
### What?

_I have added/removed/altered:_

- Removed `managed_policy_arns` from the IAM roles we create in the ECS service module
- Replaced the required attachments for ECS with `aws_iam_role_policy_attachment` resources
- Added extra `aws_iam_role_policy_attachment` resources so the module can take in additional policy ARNs

### Why?

_I am doing this because:_

Currently in the ECS service module, we're creating the service roles and provisioning them with [`managed_policy_arns`][0], but when we want to attach additional policy down the line to allow the service roles access to SecretsManager Secrets/ SSM parameters and KMS keys, using `aws_iam_role_policy_attachment` means we fall foul of [this application note][1]:

> **Warning**
> For a given role, this resource is incompatible with using the [aws_iam_role resource](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/iam_role) managed_policy_arns argument.
> When using that argument and this resource, both will attempt to manage the role's managed policy attachments and Terraform will show a permanent difference.

[0]: https://github.com/trade-tariff/trade-tariff-platform-terraform-modules/blob/main/aws/ecs-service/iam.tf#L15
[1]: https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/iam_role_policy_attachment

This means that despite creating additional attachments downstream, the two resources will fight with each other over who has complete control of policy management for the given role. In successive `terraform apply` steps, this means that any additional policies we specify could potentially be removed, as `managed_policy_arns` treats them as policies applied out-of-band, and attempts to discard them. There could be, at any stage of a deployment, an unknown state of the role's attached policies.

We need to be able to pass in extra policies so that the execution role(s) can reach out to AWS services like SecretsManager, SSM Parameter Store, and KMS - so that they can fetch, decrypt, and retrieve secret values to pass to the containers.