### PR TITLE
BAU: Set timeouts via variable

### DIFF
--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -67,6 +67,7 @@ No modules.
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to all resources in this module. | `map(string)` | `{}` | no |
 | <a name="input_target_group_arn"></a> [target\_group\_arn](#input\_target\_group\_arn) | ARN of the load balancer target group. | `string` | n/a | yes |
 | <a name="input_task_role_policy_arns"></a> [task\_role\_policy\_arns](#input\_task\_role\_policy\_arns) | A list of additional policy ARNs to attach to the service's task role. | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | Timeout time for the ECS service to become stable before producing a Terraform error. | `string` | `"15m"` | no |
 | <a name="input_wait_for_steady_state"></a> [wait\_for\_steady\_state](#input\_wait\_for\_steady\_state) | Whether to wait for the service to become stable akin to `aws ecs wait services-stable`. Defaults to true. | `bool` | `true` | no |
 
 ## Outputs

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -23,9 +23,9 @@ resource "aws_ecs_service" "this" {
   wait_for_steady_state              = var.wait_for_steady_state
 
   timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
+    create = var.timeout
+    update = var.timeout
+    delete = var.timeout
   }
 
   lifecycle {

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -154,3 +154,9 @@ variable "task_role_policy_arns" {
   type        = list(string)
   default     = [""]
 }
+
+variable "timeout" {
+  description = "Timeout time for the ECS service to become stable before producing a Terraform error."
+  type        = string
+  default     = "15m"
+}


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Set the ECS service timeout through a variable.

### Why?

I am doing this because:

- We can't set deregistration delay with an Application Load Balancer target group, so there's no way of terminating draining connections faster.
- We may wish to increase this per-environment later if we have a lot of tasks.
