### PR TITLE
HOTT-3551: Expose OpenSearch Domain ARN

### DIFF
--- a/aws/opensearch/README.md
+++ b/aws/opensearch/README.md
@@ -3,20 +3,24 @@
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.67.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.67.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5.1 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> 4.0.1 |
+| <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | >= 4.3 |
 
 ## Resources
 
@@ -50,7 +54,6 @@ No requirements.
 | <a name="input_master_instance_count"></a> [master\_instance\_count](#input\_master\_instance\_count) | The number of dedicated master nodes in the cluster. | `number` | `3` | no |
 | <a name="input_master_instance_enabled"></a> [master\_instance\_enabled](#input\_master\_instance\_enabled) | Indicates whether dedicated master nodes are enabled for the cluster. | `bool` | `true` | no |
 | <a name="input_master_instance_type"></a> [master\_instance\_type](#input\_master\_instance\_type) | The type of EC2 instances to run for each master node. A list of available instance types can you find at https://aws.amazon.com/en/opensearch-service/pricing/#On-Demand_instance_pricing | `string` | `"t3.small.search"` | no |
-| <a name="input_master_user_arn"></a> [master\_user\_arn](#input\_master\_user\_arn) | The ARN for the master user of the cluster. If not specified, then it defaults to using the IAM user that is making the request. | `string` | `""` | no |
 | <a name="input_master_user_password"></a> [master\_user\_password](#input\_master\_user\_password) | The password for the master\_user\_name | `string` | `null` | no |
 | <a name="input_master_user_username"></a> [master\_user\_username](#input\_master\_user\_username) | This username receives full permissions to the cluster, equivalent to a new master user, but can only use those permissions within Dashboards. | `string` | `null` | no |
 | <a name="input_ssm_secret_name"></a> [ssm\_secret\_name](#input\_ssm\_secret\_name) | The name of the ssm parameter where to store the access credentials | `string` | n/a | yes |
@@ -61,5 +64,7 @@ No requirements.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_domain_arn"></a> [domain\_arn](#output\_domain\_arn) | ARN of the OpenSearch domain. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/opensearch/main.tf
+++ b/aws/opensearch/main.tf
@@ -1,6 +1,6 @@
 module "acm" {
   source  = "terraform-aws-modules/acm/aws"
-  version = "~> 4.0.1"
+  version = ">= 4.3"
 
   domain_name = "${var.cluster_name}.${data.aws_route53_zone.opensearch.name}"
   zone_id     = data.aws_route53_zone.opensearch.id

--- a/aws/opensearch/outputs.tf
+++ b/aws/opensearch/outputs.tf
@@ -1,0 +1,4 @@
+output "domain_arn" {
+  description = "ARN of the OpenSearch domain."
+  value       = aws_opensearch_domain.opensearch.arn
+}

--- a/aws/opensearch/variables.tf
+++ b/aws/opensearch/variables.tf
@@ -26,12 +26,6 @@ variable "create_service_role" {
   default     = false
 }
 
-variable "master_user_arn" {
-  description = "The ARN for the master user of the cluster. If not specified, then it defaults to using the IAM user that is making the request."
-  type        = string
-  default     = ""
-}
-
 variable "master_instance_enabled" {
   description = "Indicates whether dedicated master nodes are enabled for the cluster."
   type        = bool

--- a/aws/opensearch/versions.tf
+++ b/aws/opensearch/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.67.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.1"
+    }
+  }
+}


### PR DESCRIPTION
### Jira link

[HOTT-3551](https://transformuk.atlassian.net/browse/HOTT-3551)

### What?

_I have added/removed/altered:_

- Added output for the OpenSearch domain ARN.
- Bumped the ACM module version inside this module as it was out of date.
- Removed an unused variable.


### Why?

_I am doing this because:_

- We need the ARN of the OpenSearch domain so that we can use it where the module is called to create specific policies.
