### PR TITLE
BAU: Use count for additional policy attachments

### DIFF
--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -52,7 +52,7 @@ No modules.
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Base docker image to use. | `string` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Tag of the docker image to use. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name, i.e. `development`, `staging`, `production`. | `string` | n/a | yes |
-| <a name="input_execution_role_policy_arns"></a> [execution\_role\_policy\_arns](#input\_execution\_role\_policy\_arns) | A list of additional policy ARNs to attach to the service's execution role. | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
+| <a name="input_execution_role_policy_arns"></a> [execution\_role\_policy\_arns](#input\_execution\_role\_policy\_arns) | A list of additional policy ARNs to attach to the service's execution role. | `list(string)` | `[]` | no |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | A maximum capacity for autoscaling. | `number` | n/a | yes |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory limits for container. | `number` | `512` | no |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | A minimum capacity for autoscaling. Defaults to 1. | `number` | `1` | no |
@@ -66,7 +66,7 @@ No modules.
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs to place the service into. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to all resources in this module. | `map(string)` | `{}` | no |
 | <a name="input_target_group_arn"></a> [target\_group\_arn](#input\_target\_group\_arn) | ARN of the load balancer target group. | `string` | n/a | yes |
-| <a name="input_task_role_policy_arns"></a> [task\_role\_policy\_arns](#input\_task\_role\_policy\_arns) | A list of additional policy ARNs to attach to the service's task role. | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
+| <a name="input_task_role_policy_arns"></a> [task\_role\_policy\_arns](#input\_task\_role\_policy\_arns) | A list of additional policy ARNs to attach to the service's task role. | `list(string)` | `[]` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Timeout time for the ECS service to become stable before producing a Terraform error. | `string` | `"15m"` | no |
 | <a name="input_wait_for_steady_state"></a> [wait\_for\_steady\_state](#input\_wait\_for\_steady\_state) | Whether to wait for the service to become stable akin to `aws ecs wait services-stable`. Defaults to true. | `bool` | `true` | no |
 

--- a/aws/ecs-service/iam.tf
+++ b/aws/ecs-service/iam.tf
@@ -20,9 +20,9 @@ resource "aws_iam_role_policy_attachment" "execution_role_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "execution_role_additional_policies" {
-  for_each   = toset(compact(var.execution_role_policy_arns))
+  count      = length(var.execution_role_policy_arns)
   role       = aws_iam_role.execution_role.name
-  policy_arn = each.value
+  policy_arn = var.execution_role_policy_arns[count.index]
 }
 
 resource "aws_iam_role" "task_role" {
@@ -36,7 +36,7 @@ resource "aws_iam_role_policy_attachment" "task_role_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "task_role_additional_policies" {
-  for_each   = toset(compact(var.task_role_policy_arns))
+  count      = length(var.task_role_policy_arns)
   role       = aws_iam_role.task_role.name
-  policy_arn = each.value
+  policy_arn = var.task_role_policy_arns[count.index]
 }

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -146,13 +146,13 @@ variable "cloudwatch_log_group_name" {
 variable "execution_role_policy_arns" {
   description = "A list of additional policy ARNs to attach to the service's execution role."
   type        = list(string)
-  default     = [""]
+  default     = []
 }
 
 variable "task_role_policy_arns" {
   description = "A list of additional policy ARNs to attach to the service's task role."
   type        = list(string)
-  default     = [""]
+  default     = []
 }
 
 variable "timeout" {


### PR DESCRIPTION
### What?

_I have added/removed/altered:_

- Changed the additional policy attachment resources to use `count` instead of `for_each`.
- Updated the variable defaults inline with this change.

### Why?

_I am doing this because:_

Using `for_each` here leads to a common pitfall, and a plan-time error:

> The “for_each” value depends on resource attributes that cannot be
> determined until apply, so Terraform cannot predict how many instances
> will be created.

What we want to do instead is use `count`, which will allow us to use inputs that are not known until apply time.

