### PR TITLE
HOTT-3673: Add Service Discovery Support

### DIFF
--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -33,10 +33,12 @@ No modules.
 | [aws_iam_role_policy_attachment.execution_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.task_role_additional_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.task_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_service_discovery_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_service) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
 | [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_cluster) | data source |
 | [aws_iam_policy_document.ecs_tasks_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_service_discovery_dns_namespace.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/service_discovery_dns_namespace) | data source |
 
 ## Inputs
 
@@ -56,6 +58,7 @@ No modules.
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | A maximum capacity for autoscaling. | `number` | n/a | yes |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory limits for container. | `number` | `512` | no |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | A minimum capacity for autoscaling. Defaults to 1. | `number` | `1` | no |
+| <a name="input_private_dns_namespace"></a> [private\_dns\_namespace](#input\_private\_dns\_namespace) | Private DNS namespace name. If provided, enables service discovery. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region. | `string` | n/a | yes |
 | <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of security group IDs to asssociate with the service. | `list(string)` | n/a | yes |
 | <a name="input_service_count"></a> [service\_count](#input\_service\_count) | Number of replicas of the service to create. Defaults to 1. | `number` | `1` | no |

--- a/aws/ecs-service/locals.tf
+++ b/aws/ecs-service/locals.tf
@@ -40,3 +40,9 @@ data "aws_ecs_cluster" "this" {
 data "aws_cloudwatch_log_group" "this" {
   name = var.cloudwatch_log_group_name
 }
+
+data "aws_service_discovery_dns_namespace" "this" {
+  count = var.private_dns_namespace != null ? 1 : 0
+  name  = var.private_dns_namespace
+  type  = "DNS_PRIVATE"
+}

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -18,6 +18,13 @@ resource "aws_ecs_service" "this" {
     subnets          = var.subnet_ids
   }
 
+  dynamic "service_registries" {
+    for_each = var.private_dns_namespace != null ? [true] : []
+    content {
+      registry_arn = aws_service_discovery_service.this[0].arn
+    }
+  }
+
   deployment_maximum_percent         = var.deployment_maximum_percent
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
   wait_for_steady_state              = var.wait_for_steady_state
@@ -101,4 +108,22 @@ resource "aws_appautoscaling_policy" "this" {
   }
 
   depends_on = [aws_appautoscaling_target.this]
+}
+
+resource "aws_service_discovery_service" "this" {
+  count = var.private_dns_namespace != null ? 1 : 0
+  name  = var.service_name
+
+  dns_config {
+    namespace_id   = data.aws_service_discovery_dns_namespace.this[0].id
+    routing_policy = "MULTIVALUE"
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+  }
+
+  health_check_custom_config {
+    failure_threshold = 5
+  }
 }

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -122,8 +122,4 @@ resource "aws_service_discovery_service" "this" {
       type = "A"
     }
   }
-
-  health_check_custom_config {
-    failure_threshold = 5
-  }
 }

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -160,3 +160,9 @@ variable "timeout" {
   type        = string
   default     = "15m"
 }
+
+variable "private_dns_namespace" {
+  description = "Private DNS namespace name. If provided, enables service discovery."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
### Jira link

This PR forms part of [HOTT-3673](https://transformuk.atlassian.net/browse/HOTT-3673).

### What?

_I have added/removed/altered:_

- Added support for Service Discovery, allowing a Service Discovery Service to be created.

### Why?

_I am doing this because:_

- Currently, the module doesn't support service discovery and assumes that the service will have a target group attached.