### PR TITLE
BAU: Allow optional CNAME or A record

### DIFF
--- a/aws/cloudfront/README.md
+++ b/aws/cloudfront/README.md
@@ -21,7 +21,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_cloudfront_distribution.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) | resource |
-| [aws_route53_record.cloudfront_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.alias_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.cname_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 
 ## Inputs
 
@@ -30,6 +31,8 @@ No modules.
 | <a name="input_aliases"></a> [aliases](#input\_aliases) | Extra CNAMEs (alternate domain names), if any, for this distribution. | `list(string)` | `null` | no |
 | <a name="input_cache_behavior"></a> [cache\_behavior](#input\_cache\_behavior) | The map of cache behaviors for this distribution. Key `default` will be used as the default cache behavior, all other keys will be used as ordered list of cache behaviors. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0. | `any` | `null` | no |
 | <a name="input_comment"></a> [comment](#input\_comment) | Any comments you want to include about the distribution. | `string` | `null` | no |
+| <a name="input_create_alias"></a> [create\_alias](#input\_create\_alias) | Whether to create a Route 53 A record. | `bool` | `false` | no |
+| <a name="input_create_cname"></a> [create\_cname](#input\_create\_cname) | Whether to create a Route 53 CNAME record. | `bool` | `false` | no |
 | <a name="input_create_distribution"></a> [create\_distribution](#input\_create\_distribution) | Controls if CloudFront distribution should be created | `bool` | `true` | no |
 | <a name="input_custom_error_response"></a> [custom\_error\_response](#input\_custom\_error\_response) | One or more custom error response elements | `any` | `{}` | no |
 | <a name="input_default_root_object"></a> [default\_root\_object](#input\_default\_root\_object) | The object that you want CloudFront to return (for example, index.html) when an end user requests the root URL. | `string` | `null` | no |

--- a/aws/cloudfront/main.tf
+++ b/aws/cloudfront/main.tf
@@ -166,8 +166,21 @@ resource "aws_cloudfront_distribution" "this" {
   }
 }
 
-resource "aws_route53_record" "cloudfront_record" {
-  count           = var.aliases != null ? length(var.aliases) : 0
+resource "aws_route53_record" "alias_record" {
+  count   = var.aliases != null && var.create_alias ? length(var.aliases) : 0
+  name    = element(var.aliases, count.index)
+  type    = "A"
+  zone_id = var.route53_zone_id
+
+  alias {
+    name                   = aws_cloudfront_distribution.this.domain_name
+    zone_id                = aws_cloudfront_distribution.this.hosted_zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "cname_record" {
+  count           = var.aliases != null && var.create_cname ? length(var.aliases) : 0
   name            = element(var.aliases, count.index)
   type            = "CNAME"
   ttl             = 60

--- a/aws/cloudfront/variables.tf
+++ b/aws/cloudfront/variables.tf
@@ -126,3 +126,15 @@ variable "health_check_id" {
   type        = string
   default     = null
 }
+
+variable "create_alias" {
+  description = "Whether to create a Route 53 A record."
+  type        = bool
+  default     = false
+}
+
+variable "create_cname" {
+  description = "Whether to create a Route 53 CNAME record."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Added configurable `CNAME` or `A` record selection for CloudFront module.

### Why?

I am doing this because:

- Per RFC 1912 section 2.4:

  > A CNAME record is not allowed to coexist with any other data.

- We need to use an `A` record for the origin instead of a `CNAME` as we want it at the apex.