### PR TITLE
BAU: Allow Enable ECS Exec

### DIFF
--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -53,6 +53,7 @@ No modules.
 | <a name="input_deployment_minimum_healthy_percent"></a> [deployment\_minimum\_healthy\_percent](#input\_deployment\_minimum\_healthy\_percent) | Minimum healthy percentage for a deployment. Defaults to 0, disabling this check. | `number` | `0` | no |
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Base docker image to use. | `string` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Tag of the docker image to use. | `string` | n/a | yes |
+| <a name="input_enable_ecs_exec"></a> [enable\_ecs\_exec](#input\_enable\_ecs\_exec) | Whether to enable AWS ECS Exec for the task. Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name, i.e. `development`, `staging`, `production`. | `string` | n/a | yes |
 | <a name="input_execution_role_policy_arns"></a> [execution\_role\_policy\_arns](#input\_execution\_role\_policy\_arns) | A list of additional policy ARNs to attach to the service's execution role. | `list(string)` | `[]` | no |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | A maximum capacity for autoscaling. | `number` | n/a | yes |

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -6,6 +6,8 @@ resource "aws_ecs_service" "this" {
   launch_type      = "FARGATE"
   platform_version = "LATEST"
 
+  enable_execute_command = var.enable_ecs_exec
+
   load_balancer {
     container_name   = var.service_name
     container_port   = var.container_port

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -166,3 +166,9 @@ variable "private_dns_namespace" {
   type        = string
   default     = null
 }
+
+variable "enable_ecs_exec" {
+  description = "Whether to enable AWS ECS Exec for the task. Defaults to `false`."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Create a boolean to enable ECS Exec on the task.

### Why?

I am doing this because:

- It's useful for debugging in development.