### PR TITLE
BAU: Output CloudFront Domain Name and Zone ID

### DIFF
--- a/aws/cloudfront/README.md
+++ b/aws/cloudfront/README.md
@@ -57,5 +57,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_aws_cloudfront_distribution_arn"></a> [aws\_cloudfront\_distribution\_arn](#output\_aws\_cloudfront\_distribution\_arn) | n/a |
+| <a name="output_aws_cloudfront_distribution_domain_name"></a> [aws\_cloudfront\_distribution\_domain\_name](#output\_aws\_cloudfront\_distribution\_domain\_name) | n/a |
+| <a name="output_aws_cloudfront_distribution_hosted_zone_id"></a> [aws\_cloudfront\_distribution\_hosted\_zone\_id](#output\_aws\_cloudfront\_distribution\_hosted\_zone\_id) | n/a |
 | <a name="output_aws_cloudfront_distribution_id"></a> [aws\_cloudfront\_distribution\_id](#output\_aws\_cloudfront\_distribution\_id) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/cloudfront/outputs.tf
+++ b/aws/cloudfront/outputs.tf
@@ -5,3 +5,11 @@ output "aws_cloudfront_distribution_id" {
 output "aws_cloudfront_distribution_arn" {
   value = aws_cloudfront_distribution.this[0].arn
 }
+
+output "aws_cloudfront_distribution_domain_name" {
+  value = aws_cloudfront_distribution.this.domain_name
+}
+
+output "aws_cloudfront_distribution_hosted_zone_id" {
+  value = aws_cloudfront_distribution.this.hosted_zone_id
+}


### PR DESCRIPTION
### What?

I have:

- Added outputs for the CloudFront module for consumption in Route 53 DNS records.

### Why?

I am doing this because:

- We require some A records to the CDN.
