### PR TITLE
BAU: Upgrade WAF module to support AWS v5 provider

### DIFF
--- a/aws/waf/README.md
+++ b/aws/waf/README.md
@@ -5,14 +5,14 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.60.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.60.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/aws/waf/main.tf
+++ b/aws/waf/main.tf
@@ -284,7 +284,7 @@ resource "aws_wafv2_web_acl" "this" {
         rule_group_reference_statement {
           arn = rule.value.arn
 
-          dynamic "excluded_rule" {
+          dynamic "rule_action_override" {
             for_each = rule.value.excluded_rules
             content {
               name = excluded_rule.value

--- a/aws/waf/versions.tf
+++ b/aws/waf/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.3"
+  required_version = ">= 1.4"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.60.0"
+      version = ">= 5.0"
     }
   }
 }


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Removed `statement.rule_group_reference_statement.excluded_rule` as this no longer exists.
- Added `statement.rule_group_reference_statement.rule_action_override`.


### Why?

I am doing this because:

- We need to upgrade to the AWS v5 provider and this module is expecting v4.