### PR TITLE
BAU: Support Command Override

### DIFF
--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -47,6 +47,7 @@ No modules.
 | <a name="input_autoscaling_metrics"></a> [autoscaling\_metrics](#input\_autoscaling\_metrics) | A map of autoscaling metrics. | <pre>map(object({<br>    metric_type  = string<br>    target_value = number<br>  }))</pre> | <pre>{<br>  "cpu": {<br>    "metric_type": "ECSServiceAverageCPUUtilization",<br>    "target_value": 75<br>  },<br>  "memory": {<br>    "metric_type": "ECSServiceAverageMemoryUtilization",<br>    "target_value": 75<br>  }<br>}</pre> | no |
 | <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | CloudWatch log group to use with the service. | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the ECS Cluster to deploy the service into. | `string` | n/a | yes |
+| <a name="input_container_command"></a> [container\_command](#input\_container\_command) | String array representing the command to run in the container. First argument should be the shell to use, if required. Defaults to `null`, that is, no command override. | `list(string)` | `null` | no |
 | <a name="input_container_port"></a> [container\_port](#input\_container\_port) | Port the container should expose. | `number` | `80` | no |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU limits for container. | `number` | `256` | no |
 | <a name="input_deployment_maximum_percent"></a> [deployment\_maximum\_percent](#input\_deployment\_maximum\_percent) | Maximum deployment as a percentage of `service_count`. Defaults to 100. | `number` | `100` | no |

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -62,6 +62,8 @@ resource "aws_ecs_task_definition" "this" {
       environment = local.merged_environment
       secrets     = local.merged_secrets
 
+      command = var.container_command
+
       portMappings = [{
         protocol      = "tcp"
         containerPort = var.container_port

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -172,3 +172,9 @@ variable "enable_ecs_exec" {
   type        = bool
   default     = false
 }
+
+variable "container_command" {
+  description = "String array representing the command to run in the container. First argument should be the shell to use, if required. Defaults to `null`, that is, no command override."
+  type        = list(string)
+  default     = null
+}


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Added `command` support to the container definition in the ECS Service module.

### Why?

I am doing this because:

- We need to be able to override the Dockerfile's `CMD` instruction when we deploy the "worker mode" backend services. To do this, we need to provide `command` in the container definition.