### PR TITLE
BAU: ECS Service improvements for backend workers

### DIFF
--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -48,6 +48,7 @@ No modules.
 | <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | CloudWatch log group to use with the service. | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the ECS Cluster to deploy the service into. | `string` | n/a | yes |
 | <a name="input_container_command"></a> [container\_command](#input\_container\_command) | String array representing the command to run in the container. First argument should be the shell to use, if required. Defaults to `null`, that is, no command override. | `list(string)` | `null` | no |
+| <a name="input_container_entrypoint"></a> [container\_entrypoint](#input\_container\_entrypoint) | String array representing the entrypoint of the container. Supply to override the Dockerfile. Defaults to `null`, that is, not overriding the Dockerfile. | `list(string)` | `null` | no |
 | <a name="input_container_port"></a> [container\_port](#input\_container\_port) | Port the container should expose. | `number` | `80` | no |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU limits for container. | `number` | `256` | no |
 | <a name="input_deployment_maximum_percent"></a> [deployment\_maximum\_percent](#input\_deployment\_maximum\_percent) | Maximum deployment as a percentage of `service_count`. Defaults to 100. | `number` | `100` | no |

--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -71,7 +71,7 @@ No modules.
 | <a name="input_skip_destroy"></a> [skip\_destroy](#input\_skip\_destroy) | (Optional) Whether to retain the old revision when the resource is destroyed or replacement is necessary. Default is false. | `bool` | `false` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs to place the service into. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to all resources in this module. | `map(string)` | `{}` | no |
-| <a name="input_target_group_arn"></a> [target\_group\_arn](#input\_target\_group\_arn) | ARN of the load balancer target group. | `string` | n/a | yes |
+| <a name="input_target_group_arn"></a> [target\_group\_arn](#input\_target\_group\_arn) | ARN of the load balancer target group. | `string` | `null` | no |
 | <a name="input_task_role_policy_arns"></a> [task\_role\_policy\_arns](#input\_task\_role\_policy\_arns) | A list of additional policy ARNs to attach to the service's task role. | `list(string)` | `[]` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Timeout time for the ECS service to become stable before producing a Terraform error. | `string` | `"15m"` | no |
 | <a name="input_wait_for_steady_state"></a> [wait\_for\_steady\_state](#input\_wait\_for\_steady\_state) | Whether to wait for the service to become stable akin to `aws ecs wait services-stable`. Defaults to true. | `bool` | `true` | no |

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -62,7 +62,8 @@ resource "aws_ecs_task_definition" "this" {
       environment = local.merged_environment
       secrets     = local.merged_secrets
 
-      command = var.container_command
+      entryPoint = var.container_entrypoint
+      command    = var.container_command
 
       portMappings = [{
         protocol      = "tcp"

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -8,10 +8,13 @@ resource "aws_ecs_service" "this" {
 
   enable_execute_command = var.enable_ecs_exec
 
-  load_balancer {
-    container_name   = var.service_name
-    container_port   = var.container_port
-    target_group_arn = var.target_group_arn
+  dynamic "load_balancer" {
+    for_each = var.target_group_arn != null ? [1] : []
+    content {
+      container_name   = var.service_name
+      container_port   = var.container_port
+      target_group_arn = var.target_group_arn
+    }
   }
 
   network_configuration {

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -178,3 +178,9 @@ variable "container_command" {
   type        = list(string)
   default     = null
 }
+
+variable "container_entrypoint" {
+  description = "String array representing the entrypoint of the container. Supply to override the Dockerfile. Defaults to `null`, that is, not overriding the Dockerfile."
+  type        = list(string)
+  default     = null
+}

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -131,6 +131,7 @@ variable "autoscaling_metrics" {
 variable "target_group_arn" {
   description = "ARN of the load balancer target group."
   type        = string
+  default     = null
 }
 
 variable "security_groups" {


### PR DESCRIPTION
## What?

I have:

- Made the `load_balancer` block in the ECS service module a `dynamic`.
- Gave `target_group_arn` variable a default of `null`.
- Added support for overriding `entrypoint` in the container definition.

## Why?

I am doing this because:

- We dont want to have a load balancer configuration for the worker services, as they don't need health checking or traditional load balancing in this case.
- We need to be able to override `entrypoint` for the worker services, so that we can pass in a different command to them.