### PR TITLE
HOTT-3876: Add Blue-Green Deployment Group

### DIFF
--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -25,6 +25,8 @@ No modules.
 |------|------|
 | [aws_appautoscaling_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_policy) | resource |
 | [aws_appautoscaling_target.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
+| [aws_codedeploy_app.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_app) | resource |
+| [aws_codedeploy_deployment_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_deployment_group) | resource |
 | [aws_ecs_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_task_definition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_iam_role.execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -45,6 +47,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_autoscaling_metrics"></a> [autoscaling\_metrics](#input\_autoscaling\_metrics) | A map of autoscaling metrics. | <pre>map(object({<br>    metric_type  = string<br>    target_value = number<br>  }))</pre> | <pre>{<br>  "cpu": {<br>    "metric_type": "ECSServiceAverageCPUUtilization",<br>    "target_value": 75<br>  },<br>  "memory": {<br>    "metric_type": "ECSServiceAverageMemoryUtilization",<br>    "target_value": 75<br>  }<br>}</pre> | no |
+| <a name="input_blue_target_group_name"></a> [blue\_target\_group\_name](#input\_blue\_target\_group\_name) | Name of the blue target group. | `string` | `null` | no |
 | <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | CloudWatch log group to use with the service. | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the ECS Cluster to deploy the service into. | `string` | n/a | yes |
 | <a name="input_container_command"></a> [container\_command](#input\_container\_command) | String array representing the command to run in the container. First argument should be the shell to use, if required. Defaults to `null`, that is, no command override. | `list(string)` | `null` | no |
@@ -55,9 +58,12 @@ No modules.
 | <a name="input_deployment_minimum_healthy_percent"></a> [deployment\_minimum\_healthy\_percent](#input\_deployment\_minimum\_healthy\_percent) | Minimum healthy percentage for a deployment. Defaults to 0, disabling this check. | `number` | `0` | no |
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Base docker image to use. | `string` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Tag of the docker image to use. | `string` | n/a | yes |
+| <a name="input_enable_blue_green"></a> [enable\_blue\_green](#input\_enable\_blue\_green) | Whether to enable blue-green deployments. | `bool` | `false` | no |
 | <a name="input_enable_ecs_exec"></a> [enable\_ecs\_exec](#input\_enable\_ecs\_exec) | Whether to enable AWS ECS Exec for the task. Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name, i.e. `development`, `staging`, `production`. | `string` | n/a | yes |
 | <a name="input_execution_role_policy_arns"></a> [execution\_role\_policy\_arns](#input\_execution\_role\_policy\_arns) | A list of additional policy ARNs to attach to the service's execution role. | `list(string)` | `[]` | no |
+| <a name="input_green_target_group_name"></a> [green\_target\_group\_name](#input\_green\_target\_group\_name) | Name of the blue target group. | `string` | `null` | no |
+| <a name="input_listener_arn"></a> [listener\_arn](#input\_listener\_arn) | ARN of the load balancer listener to use with blue-green deployment. | `string` | `null` | no |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | A maximum capacity for autoscaling. | `number` | n/a | yes |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory limits for container. | `number` | `512` | no |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | A minimum capacity for autoscaling. Defaults to 1. | `number` | `1` | no |

--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -62,7 +62,7 @@ No modules.
 | <a name="input_enable_ecs_exec"></a> [enable\_ecs\_exec](#input\_enable\_ecs\_exec) | Whether to enable AWS ECS Exec for the task. Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name, i.e. `development`, `staging`, `production`. | `string` | n/a | yes |
 | <a name="input_execution_role_policy_arns"></a> [execution\_role\_policy\_arns](#input\_execution\_role\_policy\_arns) | A list of additional policy ARNs to attach to the service's execution role. | `list(string)` | `[]` | no |
-| <a name="input_green_target_group_name"></a> [green\_target\_group\_name](#input\_green\_target\_group\_name) | Name of the blue target group. | `string` | `null` | no |
+| <a name="input_green_target_group_name"></a> [green\_target\_group\_name](#input\_green\_target\_group\_name) | Name of the green target group. | `string` | `null` | no |
 | <a name="input_listener_arn"></a> [listener\_arn](#input\_listener\_arn) | ARN of the load balancer listener to use with blue-green deployment. | `string` | `null` | no |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | A maximum capacity for autoscaling. | `number` | n/a | yes |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory limits for container. | `number` | `512` | no |

--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -54,6 +54,7 @@ No modules.
 | <a name="input_container_entrypoint"></a> [container\_entrypoint](#input\_container\_entrypoint) | String array representing the entrypoint of the container. Supply to override the Dockerfile. Defaults to `null`, that is, not overriding the Dockerfile. | `list(string)` | `null` | no |
 | <a name="input_container_port"></a> [container\_port](#input\_container\_port) | Port the container should expose. | `number` | `80` | no |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU limits for container. | `number` | `256` | no |
+| <a name="input_deployment_configuration"></a> [deployment\_configuration](#input\_deployment\_configuration) | CodeDeploy deployment configuration, e.g. `CodeDeployDefault.ECSAllAtOnce`. | `string` | n/a | yes |
 | <a name="input_deployment_maximum_percent"></a> [deployment\_maximum\_percent](#input\_deployment\_maximum\_percent) | Maximum deployment as a percentage of `service_count`. Defaults to 100. | `number` | `100` | no |
 | <a name="input_deployment_minimum_healthy_percent"></a> [deployment\_minimum\_healthy\_percent](#input\_deployment\_minimum\_healthy\_percent) | Minimum healthy percentage for a deployment. Defaults to 0, disabling this check. | `number` | `0` | no |
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Base docker image to use. | `string` | n/a | yes |

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -142,7 +142,7 @@ resource "aws_codedeploy_app" "this" {
 resource "aws_codedeploy_deployment_group" "this" {
   count                  = var.enable_blue_green ? 1 : 0
   app_name               = aws_codedeploy_app.this[0].name
-  deployment_config_name = "CodeDeployDefault.ECSAllAtOnce"
+  deployment_config_name = var.deployment_configuration
   deployment_group_name  = var.service_name
   service_role_arn       = aws_iam_role.execution_role.arn
 

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -131,3 +131,60 @@ resource "aws_service_discovery_service" "this" {
     }
   }
 }
+
+resource "aws_codedeploy_app" "this" {
+  count            = var.enable_blue_green ? 1 : 0
+  compute_platform = "ECS"
+  name             = var.service_name
+  tags             = local.tags
+}
+
+resource "aws_codedeploy_deployment_group" "this" {
+  count                  = var.enable_blue_green ? 1 : 0
+  app_name               = aws_codedeploy_app.this[0].name
+  deployment_config_name = "CodeDeployDefault.ECSAllAtOnce"
+  deployment_group_name  = var.service_name
+  service_role_arn       = aws_iam_role.execution_role.arn
+
+  auto_rollback_configuration {
+    enabled = true
+    events  = ["DEPLOYMENT_FAILURE"]
+  }
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "CONTINUE_DEPLOYMENT"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action                           = "TERMINATE"
+      termination_wait_time_in_minutes = 1
+    }
+  }
+
+  deployment_style {
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type   = "BLUE_GREEN"
+  }
+
+  ecs_service {
+    cluster_name = data.aws_ecs_cluster.this.cluster_name
+    service_name = aws_ecs_service.this.name
+  }
+
+  load_balancer_info {
+    target_group_pair_info {
+      prod_traffic_route {
+        listener_arns = [var.listener_arn]
+      }
+
+      target_group {
+        name = var.blue_target_group_name
+      }
+
+      target_group {
+        name = var.green_target_group_name
+      }
+    }
+  }
+}

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -205,7 +205,7 @@ variable "blue_target_group_name" {
 }
 
 variable "green_target_group_name" {
-  description = "Name of the blue target group."
+  description = "Name of the green target group."
   type        = string
   default     = null
 }

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -185,3 +185,27 @@ variable "container_entrypoint" {
   type        = list(string)
   default     = null
 }
+
+variable "enable_blue_green" {
+  description = "Whether to enable blue-green deployments."
+  type        = bool
+  default     = false
+}
+
+variable "listener_arn" {
+  description = "ARN of the load balancer listener to use with blue-green deployment."
+  type        = string
+  default     = null
+}
+
+variable "blue_target_group_name" {
+  description = "Name of the blue target group."
+  type        = string
+  default     = null
+}
+
+variable "green_target_group_name" {
+  description = "Name of the blue target group."
+  type        = string
+  default     = null
+}

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -209,3 +209,8 @@ variable "green_target_group_name" {
   type        = string
   default     = null
 }
+
+variable "deployment_configuration" {
+  description = "CodeDeploy deployment configuration, e.g. `CodeDeployDefault.ECSAllAtOnce`."
+  type        = string
+}


### PR DESCRIPTION
### Jira link

[HOTT-3876](https://transformuk.atlassian.net/browse/HOTT-3876)

### What?

I have added/removed/altered:

- Added CodeDeploy app, deployment group resources
- Added variables to enable blue-green

### Why?

I am doing this because:

- We need to add blue-green to our services so that we don't have downtime when deploying. The easiest way to achieve that within the constraints of AWS and ECS is to use [CodeDeploy](https://docs.aws.amazon.com/AmazonECS/latest/userguide/deployment-type-bluegreen.html)

### Considerations

- I have chosen to start with `CodeDeployDefault.ECSAllAtOnce`:

  > Shifts all traﬃc to the updated Amazon ECS container at once.

  But we may wish to discuss whether we want one of the other options here. Many of them take a lot longer to achieve full traffic switching. We may want to configure this for production.