### PR TITLE
BAU: Allow CodeDeploy to assume ECS roles

### DIFF
--- a/aws/ecs-service/iam.tf
+++ b/aws/ecs-service/iam.tf
@@ -3,8 +3,11 @@ data "aws_iam_policy_document" "ecs_tasks_assume_role_policy" {
     actions = ["sts:AssumeRole"]
 
     principals {
-      type        = "Service"
-      identifiers = ["ecs-tasks.amazonaws.com"]
+      type = "Service"
+      identifiers = [
+        "ecs-tasks.amazonaws.com",
+        "codedeploy.amazonaws.com"
+      ]
     }
   }
 }


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Added `codedeploy.amazonaws.com` to the list of service principals that can assume the ECS roles.

### Why?

I am doing this because:

- In order for CodeDeploy to perform actions on the ECS service it must be able to assume these roles.