### PR TITLE
BAU: Set a default for deployment_configuration

### DIFF
--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -54,7 +54,7 @@ No modules.
 | <a name="input_container_entrypoint"></a> [container\_entrypoint](#input\_container\_entrypoint) | String array representing the entrypoint of the container. Supply to override the Dockerfile. Defaults to `null`, that is, not overriding the Dockerfile. | `list(string)` | `null` | no |
 | <a name="input_container_port"></a> [container\_port](#input\_container\_port) | Port the container should expose. | `number` | `80` | no |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU limits for container. | `number` | `256` | no |
-| <a name="input_deployment_configuration"></a> [deployment\_configuration](#input\_deployment\_configuration) | CodeDeploy deployment configuration, e.g. `CodeDeployDefault.ECSAllAtOnce`. | `string` | n/a | yes |
+| <a name="input_deployment_configuration"></a> [deployment\_configuration](#input\_deployment\_configuration) | CodeDeploy deployment configuration, e.g. `CodeDeployDefault.ECSAllAtOnce`. | `string` | `null` | no |
 | <a name="input_deployment_maximum_percent"></a> [deployment\_maximum\_percent](#input\_deployment\_maximum\_percent) | Maximum deployment as a percentage of `service_count`. Defaults to 200 for zero downtime deploys.. | `number` | `200` | no |
 | <a name="input_deployment_minimum_healthy_percent"></a> [deployment\_minimum\_healthy\_percent](#input\_deployment\_minimum\_healthy\_percent) | Minimum healthy percentage for a deployment. Defaults to 100 for zero downtime deploys. | `number` | `100` | no |
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Base docker image to use. | `string` | n/a | yes |

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -208,6 +208,7 @@ variable "green_target_group_name" {
 variable "deployment_configuration" {
   description = "CodeDeploy deployment configuration, e.g. `CodeDeployDefault.ECSAllAtOnce`."
   type        = string
+  default     = null
 }
 
 variable "enable_rollback" {


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Set a default for `deployment_configuration` of `null`.

### Why?

I am doing this because:

- Without a default, this argument is required - but it is only used when `enable_blue_green` is `true` which may not always be the case.