### PR TITLE
HOTT-2789: Support an Init Container

### DIFF
--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -64,6 +64,9 @@ No modules.
 | <a name="input_enable_rollback"></a> [enable\_rollback](#input\_enable\_rollback) | Whether to enable circuit breaker rollbacks. Defaults to `true`. | `bool` | `true` | no |
 | <a name="input_execution_role_policy_arns"></a> [execution\_role\_policy\_arns](#input\_execution\_role\_policy\_arns) | A list of additional policy ARNs to attach to the service's execution role. | `list(string)` | `[]` | no |
 | <a name="input_green_target_group_name"></a> [green\_target\_group\_name](#input\_green\_target\_group\_name) | Name of the green target group. | `string` | `null` | no |
+| <a name="input_init_container"></a> [init\_container](#input\_init\_container) | Whether to use an init container. | `bool` | `false` | no |
+| <a name="input_init_container_command"></a> [init\_container\_command](#input\_init\_container\_command) | String array representing the command to run in the init container. First argument should be the shell to use, if required. Defaults to `null`, that is, no command override. | `list(string)` | `null` | no |
+| <a name="input_init_container_entrypoint"></a> [init\_container\_entrypoint](#input\_init\_container\_entrypoint) | String array representing the entrypoint of the init container. Supply to override the Dockerfile. Defaults to `null`, that is, not overriding the Dockerfile. | `list(string)` | `null` | no |
 | <a name="input_listener_arn"></a> [listener\_arn](#input\_listener\_arn) | ARN of the load balancer listener to use with blue-green deployment. | `string` | `null` | no |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | A maximum capacity for autoscaling. | `number` | n/a | yes |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory limits for container. | `number` | `512` | no |

--- a/aws/ecs-service/locals.tf
+++ b/aws/ecs-service/locals.tf
@@ -18,10 +18,6 @@ locals {
       secrets     = var.service_secrets_config
       entryPoint  = var.init_container_entrypoint
       command     = var.init_container_command
-      portMappings = [{
-        protocol      = "tcp"
-        containerPort = var.container_port
-      }]
 
       logConfiguration = {
         logDriver = "awslogs"
@@ -38,9 +34,8 @@ locals {
       essential   = true
       environment = var.service_environment_config
       secrets     = var.service_secrets_config
-
-      entryPoint = var.container_entrypoint
-      command    = var.container_command
+      entryPoint  = var.container_entrypoint
+      command     = var.container_command
 
       portMappings = [{
         protocol      = "tcp"

--- a/aws/ecs-service/locals.tf
+++ b/aws/ecs-service/locals.tf
@@ -85,7 +85,7 @@ locals {
         awslogs-group         = data.aws_cloudwatch_log_group.this.name
       }
     }
-  }, null]
+  }]
 }
 
 data "aws_caller_identity" "current" {}

--- a/aws/ecs-service/locals.tf
+++ b/aws/ecs-service/locals.tf
@@ -63,7 +63,7 @@ locals {
     }
   ]
 
-  container_definition = {
+  container_definition = [{
     name        = var.service_name
     image       = "${var.docker_image}:${var.docker_tag}"
     essential   = true
@@ -85,7 +85,7 @@ locals {
         awslogs-group         = data.aws_cloudwatch_log_group.this.name
       }
     }
-  }
+  }, null]
 }
 
 data "aws_caller_identity" "current" {}

--- a/aws/ecs-service/locals.tf
+++ b/aws/ecs-service/locals.tf
@@ -2,25 +2,6 @@ locals {
   account_id  = data.aws_caller_identity.current.account_id
   cluster_arn = data.aws_ecs_cluster.this.arn
 
-  # TODO:
-  # pre-populate these with things that are common between ALL applications
-  default_environment_config = []
-  default_secrets_config     = []
-
-  merged_secrets = distinct(
-    concat(
-      var.service_secrets_config,
-      local.default_secrets_config
-    )
-  )
-
-  merged_environment = distinct(
-    concat(
-      var.service_environment_config,
-      local.default_environment_config
-    )
-  )
-
   tags = merge(
     {
       Terraform = "true"
@@ -28,6 +9,83 @@ locals {
     var.tags,
   )
 
+  init_container_definition = [
+    {
+      name        = "${var.service_name}-init"
+      image       = "${var.docker_image}:${var.docker_tag}"
+      essential   = false
+      environment = var.service_environment_config
+      secrets     = var.service_secrets_config
+      entryPoint  = var.init_container_entrypoint
+      command     = var.init_container_command
+      portMappings = [{
+        protocol      = "tcp"
+        containerPort = var.container_port
+      }]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-region        = var.region
+          awslogs-stream-prefix = "ecs"
+          awslogs-group         = data.aws_cloudwatch_log_group.this.name
+        }
+      }
+    },
+    {
+      name        = var.service_name
+      image       = "${var.docker_image}:${var.docker_tag}"
+      essential   = true
+      environment = var.service_environment_config
+      secrets     = var.service_secrets_config
+
+      entryPoint = var.container_entrypoint
+      command    = var.container_command
+
+      portMappings = [{
+        protocol      = "tcp"
+        containerPort = var.container_port
+      }]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-region        = var.region
+          awslogs-stream-prefix = "ecs"
+          awslogs-group         = data.aws_cloudwatch_log_group.this.name
+        }
+      }
+
+      dependsOn = [{
+        containerName = "${var.service_name}-init"
+        condition     = "COMPLETE"
+      }]
+    }
+  ]
+
+  container_definition = {
+    name        = var.service_name
+    image       = "${var.docker_image}:${var.docker_tag}"
+    essential   = true
+    environment = var.service_environment_config
+    secrets     = var.service_secrets_config
+    entryPoint  = var.container_entrypoint
+    command     = var.container_command
+
+    portMappings = [{
+      protocol      = "tcp"
+      containerPort = var.container_port
+    }]
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        awslogs-region        = var.region
+        awslogs-stream-prefix = "ecs"
+        awslogs-group         = data.aws_cloudwatch_log_group.this.name
+      }
+    }
+  }
 }
 
 data "aws_caller_identity" "current" {}

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -63,7 +63,7 @@ resource "aws_ecs_task_definition" "this" {
   memory                   = var.memory
 
   # disgusting hack, see https://stackoverflow.com/a/74935621
-  container_definitions = flatten([local.init_container_definition, local.container_definition][var.init_container ? 0 : 1])
+  container_definitions = jsonencode([local.init_container_definition, local.container_definition][var.init_container ? 0 : 1])
 
   runtime_platform {
     operating_system_family = "LINUX"

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -61,7 +61,9 @@ resource "aws_ecs_task_definition" "this" {
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.cpu
   memory                   = var.memory
-  container_definitions    = var.init_container ? local.init_container_definition : local.container_definition
+
+  # disgusting hack, see https://stackoverflow.com/a/74935621
+  container_definitions = flatten([local.init_container_definition, local.container_definition][var.init_container ? 0 : 1])
 
   runtime_platform {
     operating_system_family = "LINUX"

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -61,33 +61,7 @@ resource "aws_ecs_task_definition" "this" {
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.cpu
   memory                   = var.memory
-
-  container_definitions = jsonencode([
-    {
-      name        = var.service_name
-      image       = "${var.docker_image}:${var.docker_tag}"
-      essential   = true
-      environment = local.merged_environment
-      secrets     = local.merged_secrets
-
-      entryPoint = var.container_entrypoint
-      command    = var.container_command
-
-      portMappings = [{
-        protocol      = "tcp"
-        containerPort = var.container_port
-      }]
-
-      logConfiguration = {
-        logDriver = "awslogs"
-        options = {
-          awslogs-region        = var.region
-          awslogs-stream-prefix = "ecs"
-          awslogs-group         = data.aws_cloudwatch_log_group.this.name
-        }
-      }
-    }
-  ])
+  container_definitions    = var.init_container ? local.init_container_definition : local.container_definition
 
   runtime_platform {
     operating_system_family = "LINUX"

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -17,6 +17,8 @@ resource "aws_ecs_service" "this" {
     }
   }
 
+  health_check_grace_period_seconds = 60
+
   network_configuration {
     assign_public_ip = false
     security_groups  = var.security_groups

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -17,8 +17,6 @@ resource "aws_ecs_service" "this" {
     }
   }
 
-  health_check_grace_period_seconds = 60
-
   network_configuration {
     assign_public_ip = false
     security_groups  = var.security_groups

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -216,3 +216,23 @@ variable "enable_rollback" {
   type        = bool
   default     = true
 }
+
+### Init Container
+
+variable "init_container" {
+  description = "Whether to use an init container."
+  type        = bool
+  default     = false
+}
+
+variable "init_container_entrypoint" {
+  description = "String array representing the entrypoint of the init container. Supply to override the Dockerfile. Defaults to `null`, that is, not overriding the Dockerfile."
+  type        = list(string)
+  default     = null
+}
+
+variable "init_container_command" {
+  description = "String array representing the command to run in the init container. First argument should be the shell to use, if required. Defaults to `null`, that is, no command override."
+  type        = list(string)
+  default     = null
+}


### PR DESCRIPTION
### Jira link

[HOTT-2789](https://transformuk.atlassian.net/browse/HOTT-2789)

### What?

I have added/removed/altered:

- Added support for running an init container which has individual overrides for entrypoint and command.

### Why?

I am doing this because:

- The backend service has a lot of complexity that we need to rationalise as part of the migration to AWS. Namely, I would like to move the database migration steps out of a piece of arbitrary CircleCi compute and deal with it using an init container.

  - This is common in [Kubernetes](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/), but as we are using ECS we need to adapt this approach by using the `dependsOn` property available to ECS container definitions.
- With this approach, we can create a set of init containers that run the database migration step, either exit cleanly and launch the new backend version, or fail gracefully giving us indication that the migration step failed.

- This allows us to ensure that database migrations are always applied before we attempt to deploy a new version of the backend.