### PR TITLE
HOTT-4088 - added terraform module for cloudwatch log group export to s3

### DIFF
--- a/aws/cloudwatch_log_exporter/README.md
+++ b/aws/cloudwatch_log_exporter/README.md
@@ -1,0 +1,49 @@
+This module is derived from https://github.com/DNXLabs/terraform-aws-log-exporter/ with minor changes. 
+It creates a lambda function that exports log groups on the AWS account and region deployed(default every 4 hours).
+
+It will only export each log group if it has the tag ExportToS3=true, if the last export was more than 24 hours ago it creates an export task to the S3_BUCKET defined saving the current timestamp in a SSM parameter.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.3 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.3 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_event_rule.log_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.log_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_iam_role.log_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.log_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_lambda_function.log_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.log_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [archive_file.log_exporter](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cloudwatch_logs_export_bucket"></a> [cloudwatch\_logs\_export\_bucket](#input\_cloudwatch\_logs\_export\_bucket) | Bucket to export logs | `string` | `""` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Build environment | `string` | `""` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/cloudwatch_log_exporter/lambda/cloudwatch-to-s3.py
+++ b/aws/cloudwatch_log_exporter/lambda/cloudwatch-to-s3.py
@@ -1,0 +1,80 @@
+import boto3
+import os
+from pprint import pprint
+import time
+
+logs = boto3.client('logs')
+ssm = boto3.client('ssm')
+
+def lambda_handler(event, context):
+    extra_args = {}
+    log_groups = []
+    log_groups_to_export = []
+
+    if 'S3_BUCKET' not in os.environ:
+        print("Error: S3_BUCKET not defined")
+        return
+
+    print("--> S3_BUCKET=%s" % os.environ["S3_BUCKET"])
+
+    while True:
+        response = logs.describe_log_groups(**extra_args)
+        log_groups = log_groups + response['logGroups']
+
+        if not 'nextToken' in response:
+            break
+        extra_args['nextToken'] = response['nextToken']
+
+    for log_group in log_groups:
+        response = logs.list_tags_log_group(logGroupName=log_group['logGroupName'])
+        log_group_tags = response['tags']
+        if 'ExportToS3' in log_group_tags and log_group_tags['ExportToS3'] == 'true':
+            log_groups_to_export.append(log_group['logGroupName'])
+
+    for log_group_name in log_groups_to_export:
+        ssm_parameter_name = ("/log-exporter-last-export/%s" % log_group_name).replace("//", "/")
+        try:
+            ssm_response = ssm.get_parameter(Name=ssm_parameter_name)
+            ssm_value = ssm_response['Parameter']['Value']
+        except ssm.exceptions.ParameterNotFound:
+            ssm_value = "0"
+
+        export_to_time = int(round(time.time() * 1000))
+
+        print("--> Exporting %s to %s" % (log_group_name, os.environ['S3_BUCKET']))
+
+        if export_to_time - int(ssm_value) < (24 * 60 * 60 * 1000):
+            # Haven't been 24hrs from the last export of this log group
+            print("    Skipped until 24hrs from last export is completed")
+            continue
+
+        max_retries = 10
+        while max_retries > 0:
+            try:
+                response = logs.create_export_task(
+                    logGroupName=log_group_name,
+                    fromTime=int(ssm_value),
+                    to=export_to_time,
+                    destination=os.environ['S3_BUCKET'],
+                    destinationPrefix=os.environ['AWS_ACCOUNT'] + '/' + log_group_name.strip('/')
+                )
+                print("    Task created: %s" % response['taskId'])
+                ssm_response = ssm.put_parameter(
+                    Name=ssm_parameter_name,
+                    Type="String",
+                    Value=str(export_to_time),
+                    Overwrite=True)
+
+                break
+
+            except logs.exceptions.LimitExceededException:
+                max_retries = max_retries - 1
+                print("    Need to wait until all tasks are finished (LimitExceededException). Continuing %s additional times" % (max_retries))
+                time.sleep(5)
+                continue
+
+            except Exception as e:
+                print("    Error exporting %s: %s" % (log_group_name, getattr(e, 'message', repr(e))))
+                break
+
+        

--- a/aws/cloudwatch_log_exporter/main.tf
+++ b/aws/cloudwatch_log_exporter/main.tf
@@ -1,0 +1,128 @@
+data "archive_file" "log_exporter" {
+  type        = "zip"
+  source_file = "${path.module}/lambda/cloudwatch-to-s3.py"
+  output_path = "${path.module}/lambda/tmp/cloudwatch-to-s3.zip"
+}
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "log_exporter" {
+  name = "log-exporter-${var.environment}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "log_exporter" {
+  name = "log-exporter-${var.environment}"
+  role = aws_iam_role.log_exporter.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "logs:CreateExportTask",
+        "logs:Describe*",
+        "logs:ListTagsLogGroup"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "ssm:DescribeParameters",
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:GetParametersByPath",
+        "ssm:PutParameter"
+      ],
+      "Resource": "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/log-exporter-last-export/*",
+      "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/log-exporter-*",
+      "Effect": "Allow"
+    },
+    {
+        "Sid": "AllowCrossAccountObjectAcc",
+        "Effect": "Allow",
+        "Action": [
+            "s3:PutObject",
+            "s3:PutObjectACL"
+        ],
+        "Resource": "arn:aws:s3:::${var.cloudwatch_logs_export_bucket}/*"
+    },
+    {
+        "Sid": "AllowCrossAccountBucketAcc",
+        "Effect": "Allow",
+        "Action": [
+            "s3:PutBucketAcl",
+            "s3:GetBucketAcl"
+        ],
+        "Resource": "arn:aws:s3:::${var.cloudwatch_logs_export_bucket}"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "log_exporter" {
+  filename         = data.archive_file.log_exporter.output_path
+  function_name    = "log-exporter-${var.environment}"
+  role             = aws_iam_role.log_exporter.arn
+  handler          = "cloudwatch-to-s3.lambda_handler"
+  source_code_hash = data.archive_file.log_exporter.output_base64sha256
+  timeout          = 300
+
+  runtime = "python3.8"
+
+  environment {
+    variables = {
+      S3_BUCKET   = var.cloudwatch_logs_export_bucket,
+      AWS_ACCOUNT = data.aws_caller_identity.current.account_id
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "log_exporter" {
+  name                = "log-exporter-${var.environment}"
+  description         = "Fires periodically to export logs to S3"
+  schedule_expression = "rate(4 hours)"
+}
+
+resource "aws_cloudwatch_event_target" "log_exporter" {
+  rule      = aws_cloudwatch_event_rule.log_exporter.name
+  target_id = "log-exporter-${var.environment}"
+  arn       = aws_lambda_function.log_exporter.arn
+}
+
+resource "aws_lambda_permission" "log_exporter" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.log_exporter.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.log_exporter.arn
+}
+

--- a/aws/cloudwatch_log_exporter/terraform.tf
+++ b/aws/cloudwatch_log_exporter/terraform.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.3"
+    }
+  }
+}

--- a/aws/cloudwatch_log_exporter/variables.tf
+++ b/aws/cloudwatch_log_exporter/variables.tf
@@ -1,0 +1,11 @@
+variable "cloudwatch_logs_export_bucket" {
+  type        = string
+  default     = ""
+  description = "Bucket to export logs"
+}
+
+variable "environment" {
+  type        = string
+  default     = ""
+  description = "Build environment"
+}

--- a/aws/cloudwatch_log_exporter/versions.tf
+++ b/aws/cloudwatch_log_exporter/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12.0"
+}


### PR DESCRIPTION
### Jira link

HOTT-4088

### What?

I have added/removed/altered:

- [x] Added terraform module for cloudwatch log group export to s3

### Why?

I am doing this because:

-  In order to export cloudwatch logs to logging s3 buckets

