### PR TITLE
HOTT-4081 - added terraform module to send aws cloudwatch alarm alerts to slack

### DIFF
--- a/aws/aws-notify-slack/.pre-commit-config.yaml
+++ b/aws/aws-notify-slack/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.79.1
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_docs
+        args:
+          - '--args=--lockfile=false'
+      - id: terraform_tflint
+        args:
+          - '--args=--only=terraform_deprecated_interpolation'
+          - '--args=--only=terraform_deprecated_index'
+          - '--args=--only=terraform_unused_declarations'
+          - '--args=--only=terraform_comment_syntax'
+          - '--args=--only=terraform_documented_outputs'
+          - '--args=--only=terraform_documented_variables'
+          - '--args=--only=terraform_typed_variables'
+          - '--args=--only=terraform_module_pinned_source'
+          - '--args=--only=terraform_naming_convention'
+          - '--args=--only=terraform_required_version'
+          - '--args=--only=terraform_required_providers'
+          - '--args=--only=terraform_standard_module_structure'
+          - '--args=--only=terraform_workspace_remote'
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-merge-conflict
+      - id: end-of-file-fixer

--- a/aws/aws-notify-slack/README.md
+++ b/aws/aws-notify-slack/README.md
@@ -1,0 +1,101 @@
+This module is derived from official terraform module https://github.com/terraform-aws-modules/terraform-aws-notify-slack with a minor fix for IAM policy.
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.8 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.8 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | 3.2.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_iam_role.sns_feedback_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_sns_topic.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_subscription.sns_notify_slack](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cloudwatch_log_group_kms_key_id"></a> [cloudwatch\_log\_group\_kms\_key\_id](#input\_cloudwatch\_log\_group\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting log data for Lambda | `string` | `null` | no |
+| <a name="input_cloudwatch_log_group_retention_in_days"></a> [cloudwatch\_log\_group\_retention\_in\_days](#input\_cloudwatch\_log\_group\_retention\_in\_days) | Specifies the number of days you want to retain log events in log group for Lambda. | `number` | `0` | no |
+| <a name="input_cloudwatch_log_group_tags"></a> [cloudwatch\_log\_group\_tags](#input\_cloudwatch\_log\_group\_tags) | Additional tags for the Cloudwatch log group | `map(string)` | `{}` | no |
+| <a name="input_create"></a> [create](#input\_create) | Whether to create all resources | `bool` | `true` | no |
+| <a name="input_create_sns_topic"></a> [create\_sns\_topic](#input\_create\_sns\_topic) | Whether to create new SNS topic | `bool` | `true` | no |
+| <a name="input_enable_sns_topic_delivery_status_logs"></a> [enable\_sns\_topic\_delivery\_status\_logs](#input\_enable\_sns\_topic\_delivery\_status\_logs) | Whether to enable SNS topic delivery status logs | `bool` | `false` | no |
+| <a name="input_iam_policy_path"></a> [iam\_policy\_path](#input\_iam\_policy\_path) | Path of policies to that should be added to IAM role for Lambda Function | `string` | `null` | no |
+| <a name="input_iam_role_boundary_policy_arn"></a> [iam\_role\_boundary\_policy\_arn](#input\_iam\_role\_boundary\_policy\_arn) | The ARN of the policy that is used to set the permissions boundary for the role | `string` | `null` | no |
+| <a name="input_iam_role_name_prefix"></a> [iam\_role\_name\_prefix](#input\_iam\_role\_name\_prefix) | A unique role name beginning with the specified prefix | `string` | `"lambda"` | no |
+| <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | Path of IAM role to use for Lambda Function | `string` | `null` | no |
+| <a name="input_iam_role_tags"></a> [iam\_role\_tags](#input\_iam\_role\_tags) | Additional tags for the IAM role | `map(string)` | `{}` | no |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | ARN of the KMS key used for decrypting slack webhook url | `string` | `""` | no |
+| <a name="input_lambda_attach_dead_letter_policy"></a> [lambda\_attach\_dead\_letter\_policy](#input\_lambda\_attach\_dead\_letter\_policy) | Controls whether SNS/SQS dead letter notification policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
+| <a name="input_lambda_dead_letter_target_arn"></a> [lambda\_dead\_letter\_target\_arn](#input\_lambda\_dead\_letter\_target\_arn) | The ARN of an SNS topic or SQS queue to notify when an invocation fails. | `string` | `null` | no |
+| <a name="input_lambda_description"></a> [lambda\_description](#input\_lambda\_description) | The description of the Lambda function | `string` | `null` | no |
+| <a name="input_lambda_function_ephemeral_storage_size"></a> [lambda\_function\_ephemeral\_storage\_size](#input\_lambda\_function\_ephemeral\_storage\_size) | Amount of ephemeral storage (/tmp) in MB your Lambda Function can use at runtime. Valid value between 512 MB to 10,240 MB (10 GB). | `number` | `512` | no |
+| <a name="input_lambda_function_name"></a> [lambda\_function\_name](#input\_lambda\_function\_name) | The name of the Lambda function to create | `string` | `"notify_slack"` | no |
+| <a name="input_lambda_function_s3_bucket"></a> [lambda\_function\_s3\_bucket](#input\_lambda\_function\_s3\_bucket) | S3 bucket to store artifacts | `string` | `null` | no |
+| <a name="input_lambda_function_store_on_s3"></a> [lambda\_function\_store\_on\_s3](#input\_lambda\_function\_store\_on\_s3) | Whether to store produced artifacts on S3 or locally. | `bool` | `false` | no |
+| <a name="input_lambda_function_tags"></a> [lambda\_function\_tags](#input\_lambda\_function\_tags) | Additional tags for the Lambda function | `map(string)` | `{}` | no |
+| <a name="input_lambda_function_vpc_security_group_ids"></a> [lambda\_function\_vpc\_security\_group\_ids](#input\_lambda\_function\_vpc\_security\_group\_ids) | List of security group ids when Lambda Function should run in the VPC. | `list(string)` | `null` | no |
+| <a name="input_lambda_function_vpc_subnet_ids"></a> [lambda\_function\_vpc\_subnet\_ids](#input\_lambda\_function\_vpc\_subnet\_ids) | List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets. | `list(string)` | `null` | no |
+| <a name="input_lambda_role"></a> [lambda\_role](#input\_lambda\_role) | IAM role attached to the Lambda Function.  If this is set then a role will not be created for you. | `string` | `""` | no |
+| <a name="input_lambda_source_path"></a> [lambda\_source\_path](#input\_lambda\_source\_path) | The source path of the custom Lambda function | `string` | `null` | no |
+| <a name="input_log_events"></a> [log\_events](#input\_log\_events) | Boolean flag to enabled/disable logging of incoming events | `bool` | `false` | no |
+| <a name="input_putin_khuylo"></a> [putin\_khuylo](#input\_putin\_khuylo) | Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo! | `bool` | `true` | no |
+| <a name="input_recreate_missing_package"></a> [recreate\_missing\_package](#input\_recreate\_missing\_package) | Whether to recreate missing Lambda package if it is missing locally or not | `bool` | `true` | no |
+| <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations | `number` | `-1` | no |
+| <a name="input_slack_channel"></a> [slack\_channel](#input\_slack\_channel) | The name of the channel in Slack for notifications | `string` | n/a | yes |
+| <a name="input_slack_emoji"></a> [slack\_emoji](#input\_slack\_emoji) | A custom emoji that will appear on Slack messages | `string` | `":aws:"` | no |
+| <a name="input_slack_username"></a> [slack\_username](#input\_slack\_username) | The username that will appear on Slack messages | `string` | n/a | yes |
+| <a name="input_slack_webhook_url"></a> [slack\_webhook\_url](#input\_slack\_webhook\_url) | The URL of Slack webhook | `string` | n/a | yes |
+| <a name="input_sns_topic_feedback_role_description"></a> [sns\_topic\_feedback\_role\_description](#input\_sns\_topic\_feedback\_role\_description) | Description of IAM role to use for SNS topic delivery status logging | `string` | `null` | no |
+| <a name="input_sns_topic_feedback_role_force_detach_policies"></a> [sns\_topic\_feedback\_role\_force\_detach\_policies](#input\_sns\_topic\_feedback\_role\_force\_detach\_policies) | Specifies to force detaching any policies the IAM role has before destroying it. | `bool` | `true` | no |
+| <a name="input_sns_topic_feedback_role_name"></a> [sns\_topic\_feedback\_role\_name](#input\_sns\_topic\_feedback\_role\_name) | Name of the IAM role to use for SNS topic delivery status logging | `string` | `null` | no |
+| <a name="input_sns_topic_feedback_role_path"></a> [sns\_topic\_feedback\_role\_path](#input\_sns\_topic\_feedback\_role\_path) | Path of IAM role to use for SNS topic delivery status logging | `string` | `null` | no |
+| <a name="input_sns_topic_feedback_role_permissions_boundary"></a> [sns\_topic\_feedback\_role\_permissions\_boundary](#input\_sns\_topic\_feedback\_role\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the IAM role used by SNS topic delivery status logging | `string` | `null` | no |
+| <a name="input_sns_topic_feedback_role_tags"></a> [sns\_topic\_feedback\_role\_tags](#input\_sns\_topic\_feedback\_role\_tags) | A map of tags to assign to IAM the SNS topic feedback role | `map(string)` | `{}` | no |
+| <a name="input_sns_topic_kms_key_id"></a> [sns\_topic\_kms\_key\_id](#input\_sns\_topic\_kms\_key\_id) | ARN of the KMS key used for enabling SSE on the topic | `string` | `""` | no |
+| <a name="input_sns_topic_lambda_feedback_role_arn"></a> [sns\_topic\_lambda\_feedback\_role\_arn](#input\_sns\_topic\_lambda\_feedback\_role\_arn) | IAM role for SNS topic delivery status logs.  If this is set then a role will not be created for you. | `string` | `""` | no |
+| <a name="input_sns_topic_lambda_feedback_sample_rate"></a> [sns\_topic\_lambda\_feedback\_sample\_rate](#input\_sns\_topic\_lambda\_feedback\_sample\_rate) | The percentage of successful deliveries to log | `number` | `100` | no |
+| <a name="input_sns_topic_name"></a> [sns\_topic\_name](#input\_sns\_topic\_name) | The name of the SNS topic to create | `string` | n/a | yes |
+| <a name="input_sns_topic_tags"></a> [sns\_topic\_tags](#input\_sns\_topic\_tags) | Additional tags for the SNS topic | `map(string)` | `{}` | no |
+| <a name="input_subscription_filter_policy"></a> [subscription\_filter\_policy](#input\_subscription\_filter\_policy) | (Optional) A valid filter policy that will be used in the subscription to filter messages seen by the target resource. | `string` | `null` | no |
+| <a name="input_subscription_filter_policy_scope"></a> [subscription\_filter\_policy\_scope](#input\_subscription\_filter\_policy\_scope) | (Optional) A valid filter policy scope MessageAttributes\|MessageBody | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_lambda_cloudwatch_log_group_arn"></a> [lambda\_cloudwatch\_log\_group\_arn](#output\_lambda\_cloudwatch\_log\_group\_arn) | The Amazon Resource Name (ARN) specifying the log group |
+| <a name="output_lambda_iam_role_arn"></a> [lambda\_iam\_role\_arn](#output\_lambda\_iam\_role\_arn) | The ARN of the IAM role used by Lambda function |
+| <a name="output_lambda_iam_role_name"></a> [lambda\_iam\_role\_name](#output\_lambda\_iam\_role\_name) | The name of the IAM role used by Lambda function |
+| <a name="output_notify_slack_lambda_function_arn"></a> [notify\_slack\_lambda\_function\_arn](#output\_notify\_slack\_lambda\_function\_arn) | The ARN of the Lambda function |
+| <a name="output_notify_slack_lambda_function_invoke_arn"></a> [notify\_slack\_lambda\_function\_invoke\_arn](#output\_notify\_slack\_lambda\_function\_invoke\_arn) | The ARN to be used for invoking Lambda function from API Gateway |
+| <a name="output_notify_slack_lambda_function_last_modified"></a> [notify\_slack\_lambda\_function\_last\_modified](#output\_notify\_slack\_lambda\_function\_last\_modified) | The date Lambda function was last modified |
+| <a name="output_notify_slack_lambda_function_name"></a> [notify\_slack\_lambda\_function\_name](#output\_notify\_slack\_lambda\_function\_name) | The name of the Lambda function |
+| <a name="output_notify_slack_lambda_function_version"></a> [notify\_slack\_lambda\_function\_version](#output\_notify\_slack\_lambda\_function\_version) | Latest published version of your Lambda function |
+| <a name="output_slack_topic_arn"></a> [slack\_topic\_arn](#output\_slack\_topic\_arn) | The ARN of the SNS topic from which messages will be sent to Slack |
+| <a name="output_sns_topic_feedback_role_arn"></a> [sns\_topic\_feedback\_role\_arn](#output\_sns\_topic\_feedback\_role\_arn) | The Amazon Resource Name (ARN) of the IAM role used for SNS delivery status logging |
+| <a name="output_this_slack_topic_arn"></a> [this\_slack\_topic\_arn](#output\_this\_slack\_topic\_arn) | The ARN of the SNS topic from which messages will be sent to Slack (backward compatibility for version 4.x) |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/aws-notify-slack/functions/.flake8
+++ b/aws/aws-notify-slack/functions/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+max-complexity = 10
+max-line-length = 120
+exclude =
+    .pytest_cache
+    __pycache__/
+    *tests/
+    events/
+    messages/
+    snapshots/

--- a/aws/aws-notify-slack/functions/.pyproject.toml
+++ b/aws/aws-notify-slack/functions/.pyproject.toml
@@ -1,0 +1,58 @@
+[tool.black]
+line-length = 120
+target-version = ['py38']
+include = '\.pyi?$'
+verbose = true
+exclude = '''
+/(
+  | \.git
+  | \.mypy_cache
+  | dist
+  | \.pants\.d
+  | virtualenvs
+  | \.venv
+  | _build
+  | build
+  | dist
+  | snapshots
+)/
+'''
+
+[tool.isort]
+line_length = 120
+skip = '.terraform'
+sections = 'FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER'
+known_third_party = 'aws_lambda_powertools,boto3,botocore,pytest,snapshottest'
+known_first_party = 'events,notify_slack'
+indent = '    '
+
+[tool.mypy]
+namespace_packages = true
+explicit_package_bases = true
+
+no_implicit_optional = true
+implicit_reexport = false
+strict_equality = true
+
+warn_unused_configs = true
+warn_unused_ignores = true
+warn_return_any = true
+warn_redundant_casts = true
+warn_unreachable = true
+
+pretty = true
+show_column_numbers = true
+show_error_context = true
+show_error_codes = true
+show_traceback = true
+
+[tool.coverage.run]
+branch = true
+omit = ["*_test.py", "tests/*", "events/*", "messages/*", "snapshots/*", "venv/*", ".mypy_cache/*", ".pytest_cache/*"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = true
+skip_empty = true
+sort = "-Miss"
+fail_under = 75

--- a/aws/aws-notify-slack/functions/Pipfile
+++ b/aws/aws-notify-slack/functions/Pipfile
@@ -1,0 +1,36 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+boto3 = "~=1.20"
+botocore = "~=1.23"
+black = "*"
+flake8 = "*"
+isort = "*"
+mypy = "*"
+pytest = "*"
+pytest-cov = "*"
+radon = "*"
+snapshottest = "~=0.6"
+
+[requires]
+python_version = "3.8"
+
+[scripts]
+test = "python3 -m pytest --cov --cov-report=term"
+'test:updatesnapshots' = "python3 -m pytest --snapshot-update"
+cover = "python3 -m coverage html"
+complexity = "python3 -m radon cc notify_slack.py -a"
+halstead = "python3 -m radon hal notify_slack.py"
+typecheck = "python3 -m mypy . --ignore-missing-imports"
+lint = "python3 -m flake8 . --count --statistics --benchmark --exit-zero --config=.flake8"
+'lint:ci' = "python3 -m flake8 . --config=.flake8"
+imports = "python3 -m isort . --profile black"
+format = "python3 -m black ."
+
+[pipenv]
+allow_prereleases = true

--- a/aws/aws-notify-slack/functions/README.md
+++ b/aws/aws-notify-slack/functions/README.md
@@ -1,0 +1,122 @@
+# Slack Notify Lambda Functions
+
+## Conventions
+
+The following tools and conventions are used within this project:
+
+- [pipenv](https://github.com/pypa/pipenv) for managing Python dependencies and development virtualenv
+- [flake8](https://github.com/PyCQA/flake8) & [radon](https://github.com/rubik/radon) for linting and static code analysis
+- [isort](https://github.com/timothycrosley/isort) for import statement formatting
+- [black](https://github.com/ambv/black) for code formatting
+- [mypy](https://github.com/python/mypy) for static type checking
+- [pytest](https://github.com/pytest-dev/pytest) and [snapshottest](https://github.com/syrusakbary/snapshottest) for unit testing and snapshot testing
+
+## Getting Started
+
+The following instructions will help you get setup for local development and testing purposes.
+
+### Prerequisites
+
+#### [Pipenv](https://github.com/pypa/pipenv)
+
+Pipenv is used to help manage the python dependencies and local virtualenv for local testing and development. To install `pipenv` please refer to the project [installation documentation](https://github.com/pypa/pipenv#installation).
+
+Install the projects Python dependencies (with development dependencies) locally by running the following command.
+
+```bash
+  $ pipenv install --dev
+```
+
+If you add/change/modify any of the Pipfile dependencies, you can update your local virtualenv using:
+
+```bash
+  $ pipenv update
+```
+
+### Testing
+
+#### Sample Payloads
+
+In the `functions/` directory there are two folders that contain sample message payloads used for testing and validation:
+
+1. `functions/events/` contains raw events as provided by AWS. You can see a more in-depth list of example events in the (AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html)
+2. `functions/messages/` contains SNS message payloads in the form that they are delivered to the Slack notify lambda function. The `Message` attribute field is where the payload is stored that will be parsed and sent to Slack; this can be events like those described above in #1, or any string/stringified-JSON
+
+#### Unit Tests
+
+There are a number of pipenv scripts that are provided to aid in testing and ensuring the codebase is formatted properly.
+
+- `pipenv run test`: execute unit tests defined using pytest and show test coverage
+- `pipenv run lint`: show linting errors and static analysis of codebase
+- `pipenv run format`: auto-format codebase according to configurations provided
+- `pipenv run imports`: auto-format import statements according to configurations provided
+- `pipenv run typecheck`: show typecheck analysis of codebase
+
+See the `[scripts]` section of the `Pipfile` for the complete list of script commands.
+
+#### Snapshot Testing
+
+Snapshot testing is used to compare a set of given inputs to generated output snapshots to aid in unit testing. The tests are run in conjunction with the standard unit tests and the output will be shown in the cumulative output from `pipenv run test`. In theory, however, the snapshots themselves should not change unless:
+
+1. The expected output of the message payload has changed
+2. Event/message payloads have been added to or removed from the project
+
+When a change is required to update the snapshots, please do the following:
+
+1. Update the snapshots by running:
+
+```bash
+  $ pipenv run test:updatesnapshots
+  $ pipenv run format # this is necessary since the generated code follows its own style
+```
+
+2. Provide a clear reasoning within your pull request as to why the snapshots have changed
+
+#### Integration Tests
+
+Integration tests require setting up a live Slack webhook
+
+To run the unit tests:
+
+1.  Set up a dedicated slack channel as a test sandbox with it's own webhook. See [Slack Incoming Webhooks docs](https://api.slack.com/messaging/webhooks) for details.
+2.  From within the `examples/notify-slack-simple/` directory, update the `slack_*` variables to use your values:
+
+```hcl
+  slack_webhook_url = "https://hooks.slack.com/services/AAA/BBB/CCC"
+  slack_channel     = "aws-notification"
+  slack_username    = "reporter"
+```
+
+3. Deploy the resources in the `examples/notify-slack-simple/` project using Terraform
+
+```bash
+  $ terraform init && terraform apply -y
+```
+
+4.  From within the `functions/` directory, execute the integration tests locally:
+
+```bash
+  $ pipenv run python integration_test.py
+```
+
+Within the Slack channel that is associated to the webhook URL provided, you should see all of the messages arriving. You can compared the messages to the payloads in the `functions/events/` and `functions/messages` directories; there should be one Slack message per event payload/file.
+
+5. Do not forget to clean up your provisioned resources by returning to the `example/notify-slack-simple/` directory and destroying using Terraform:
+
+```bash
+  $ terraform destroy -y
+```
+
+## Supporting Additional Events
+
+To add new events with custom message formatting, the general workflow will consist of (ignoring git actions for brevity):
+
+1. Add a new example event paylod to the `functions/events/` directory; please name the file, using snake casing, in the form `<service>_<event_type>.json` such as `guardduty_finding.json` or `cloudwatch_alarm.json`
+2. In the `functions/notify_slack.py` file, add the new formatting function, following a similar naming pattern like in step #1 where the function name is `format_<service>_<event_type>()` such as `format_guardduty_finding()` or `format_cloudwatch_alarm()`
+3. (Optional) Ff there are different "severity" type levels that are to be mapped to Slack message color bars, create an enum that maps the possible serverity values to the appropriate colors. See the `CloudWatchAlarmState` and `GuardDutyFindingSeverity` for examples. The enum name should follow pascal case, Python standard, in the form of `<service><event_type><attribute_field>`
+4. Update the snapshots to include your new event payload and expected output. Note - the other snapshots should not be affected by your change, the snapshot diff should only show your new event:
+
+```bash
+  $ pipenv run test:updatesnapshots
+  $ pipenv run format # this is necessary since the generated code follows its own style
+```

--- a/aws/aws-notify-slack/functions/events/cloudwatch_alarm.json
+++ b/aws/aws-notify-slack/functions/events/cloudwatch_alarm.json
@@ -1,0 +1,10 @@
+{
+  "AlarmName": "Example",
+  "AlarmDescription": "Example alarm description.",
+  "AWSAccountId": "000000000000",
+  "NewStateValue": "ALARM",
+  "NewStateReason": "Threshold Crossed",
+  "StateChangeTime": "2017-01-12T16:30:42.236+0000",
+  "Region": "EU - Ireland",
+  "OldStateValue": "OK"
+}

--- a/aws/aws-notify-slack/functions/events/guardduty_finding_high.json
+++ b/aws/aws-notify-slack/functions/events/guardduty_finding_high.json
@@ -1,0 +1,17 @@
+{
+  "detail-type": "GuardDuty Finding",
+  "region": "us-east-1",
+  "detail": {
+    "id": "sample-id-2",
+    "title": "SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
+    "severity": 9,
+    "accountId": "123456789",
+    "description": "EC2 instance has an unprotected port which is being probed by a known malicious host.",
+    "type": "Recon:EC2 PortProbeUnprotectedPort",
+    "service": {
+      "eventFirstSeen": "2020-01-02T01:02:03Z",
+      "eventLastSeen": "2020-01-03T01:02:03Z",
+      "count": 1234
+    }
+  }
+}

--- a/aws/aws-notify-slack/functions/events/guardduty_finding_low.json
+++ b/aws/aws-notify-slack/functions/events/guardduty_finding_low.json
@@ -1,0 +1,17 @@
+{
+  "detail-type": "GuardDuty Finding",
+  "region": "us-east-1",
+  "detail": {
+    "id": "sample-id-2",
+    "title": "SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
+    "severity": 2,
+    "accountId": "123456789",
+    "description": "EC2 instance has an unprotected port which is being probed by a known malicious host.",
+    "type": "Recon:EC2 PortProbeUnprotectedPort",
+    "service": {
+      "eventFirstSeen": "2020-01-02T01:02:03Z",
+      "eventLastSeen": "2020-01-03T01:02:03Z",
+      "count": 1234
+    }
+  }
+}

--- a/aws/aws-notify-slack/functions/events/guardduty_finding_medium.json
+++ b/aws/aws-notify-slack/functions/events/guardduty_finding_medium.json
@@ -1,0 +1,17 @@
+{
+  "detail-type": "GuardDuty Finding",
+  "region": "us-east-1",
+  "detail": {
+    "id": "sample-id-2",
+    "title": "SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
+    "severity": 5,
+    "accountId": "123456789",
+    "description": "EC2 instance has an unprotected port which is being probed by a known malicious host.",
+    "type": "Recon:EC2 PortProbeUnprotectedPort",
+    "service": {
+      "eventFirstSeen": "2020-01-02T01:02:03Z",
+      "eventLastSeen": "2020-01-03T01:02:03Z",
+      "count": 1234
+    }
+  }
+}

--- a/aws/aws-notify-slack/functions/integration_test.py
+++ b/aws/aws-notify-slack/functions/integration_test.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""
+    Integration Test
+    ----------------
+
+    Executes tests against live Slack webhook
+
+"""
+
+import os
+from pprint import pprint
+from typing import List
+
+import boto3
+import pytest
+
+
+@pytest.mark.skip(reason="Execute with`pytest run python integration_test.py`")
+def _get_files(directory: str) -> List[str]:
+    """
+    Helper function to get list of files under `directory`
+
+    :params directory: directory to pull list of files from
+    :returns: list of files names under directory specified
+    """
+    return [
+        os.path.join(directory, f)
+        for f in os.listdir(directory)
+        if os.path.isfile(os.path.join(directory, f))
+    ]
+
+
+@pytest.mark.skip(reason="Execute with`pytest run python integration_test.py`")
+def invoke_lambda_handler():
+    """
+    Invoke lambda handler with sample SNS messages
+
+    Messages should arrive at the live webhook specified
+    """
+    lambda_client = boto3.client("lambda", region_name=REGION)
+
+    # These are SNS messages that invoke the lambda handler;
+    # the event payload is in the `message` field
+    messages = _get_files(directory="./messages")
+
+    for message in messages:
+        with open(message, "r") as mfile:
+            msg = mfile.read()
+        response = lambda_client.invoke(
+            FunctionName=LAMBDA_FUNCTION_NAME,
+            InvocationType="Event",
+            Payload=msg,
+        )
+        pprint(response)
+
+
+@pytest.mark.skip(reason="Execute with`pytest run python integration_test.py`")
+def publish_event_to_sns_topic():
+    """
+    Publish sample events to SNS topic created
+
+    Messages should arrive at the live webhook specified
+    """
+    sns_client = boto3.client("sns", region_name=REGION)
+
+    # These are event payloads that will get published
+    events = _get_files(directory="./events")
+
+    for event in events:
+        with open(event, "r") as efile:
+            msg = efile.read()
+        response = sns_client.publish(
+            TopicArn=SNS_TOPIC_ARN,
+            Message=msg,
+            Subject=event,
+        )
+        pprint(response)
+
+
+if __name__ == "__main__":
+    # Sourcing env vars set by `notify-slack-simple` example
+    with open(".int.env", "r") as envvarfile:
+        for line in envvarfile.readlines():
+            (_var, _val) = line.strip().split("=")
+            os.environ[_var] = _val
+
+    # Not using .get() so it fails loudly if not set (`KeyError`)
+    REGION = os.environ["REGION"]
+    LAMBDA_FUNCTION_NAME = os.environ["LAMBDA_FUNCTION_NAME"]
+    SNS_TOPIC_ARN = os.environ["SNS_TOPIC_ARN"]
+
+    invoke_lambda_handler()
+    publish_event_to_sns_topic()

--- a/aws/aws-notify-slack/functions/messages/cloudwatch_alarm.json
+++ b/aws/aws-notify-slack/functions/messages/cloudwatch_alarm.json
@@ -1,0 +1,20 @@
+{
+  "Records": [{
+    "EventSource": "aws:sns",
+    "EventVersion": "1.0",
+    "EventSubscriptionArn": "arn:aws:sns:us-east-1::ExampleTopic",
+    "Sns": {
+      "Type": "Notification",
+      "MessageId": "f86e3c5b-cd17-1ab8-80e9-c0776d4f1e7a",
+      "TopicArn": "arn:aws:sns:us-east-1:123456789012:ExampleTopic",
+      "Subject": "'OK: \"DBMigrationRequired\" in EU (London)",
+      "Message": "{\"AlarmName\": \"DBMigrationRequired\",\"AlarmDescription\": \"App is reporting \\\"A JPA error occurred(Unable to build EntityManagerFactory)\\\"\",\"AWSAccountId\": \"735598076380\",\"NewStateValue\": \"OK\",\"NewStateReason\": \"Threshold Crossed: 1 datapoint [1.0 (12\/02\/19 15:44:00)] was not less than the threshold (1.0).\",\"StateChangeTime\": \"2019-02-12T15:45:24.006+0000\",\"Region\": \"US (Virginia)\",\"OldStateValue\": \"ALARM\",\"Trigger\": {\"MetricName\": \"DBMigrationRequired\",\"Namespace\": \"LogMetrics\",\"StatisticType\": \"Statistic\",\"Statistic\": \"SUM\",\"Unit\": null,\"Dimensions\": [],\"Period\": 60,\"EvaluationPeriods\": 1,\"ComparisonOperator\": \"LessThanThreshold\",\"Threshold\": 1.0,\"TreatMissingData\": \"- TreatMissingData:NonBreaching\",\"EvaluateLowSampleCountPercentile\": \"\"}}",
+      "Timestamp": "2019-02-12T15:45:24.091Z",
+      "SignatureVersion": "1",
+      "Signature": "EXAMPLE",
+      "SigningCertUrl": "EXAMPLE",
+      "UnsubscribeUrl": "EXAMPLE",
+      "MessageAttributes": {}
+    }
+  }]
+}

--- a/aws/aws-notify-slack/functions/messages/dms_notification.json
+++ b/aws/aws-notify-slack/functions/messages/dms_notification.json
@@ -1,0 +1,20 @@
+{
+  "Records": [{
+    "EventSource": "aws:sns",
+    "EventVersion": "1.0",
+    "EventSubscriptionArn": "arn:aws:sns:eu-west-1::ExampleTopic",
+    "Sns": {
+      "Type": "Notification",
+      "MessageId": "f86e3c5b-cd17-1ab8-80e9-c0776d4f1e7a",
+      "TopicArn": "arn:aws:sns:eu-west-1:123456789012:ExampleTopic",
+      "Subject": "DMS Notification Message",
+      "Message": "{\"Event Source\": \"replication-task\",\"Event Time\": \"2019-02-12 15:45:24.091\",\"Identifier Link\": \"https:\/\/console.aws.amazon.com\/dms\/home?region=us-east-1#tasks:ids=hello-world\",\"SourceId\": \"hello-world\",\"Event ID\": \"http:\/\/docs.aws.amazon.com\/dms\/latest\/userguide\/CHAP_Events.html#DMS-EVENT-0079 \",\"Event Message\": \"Replication task has stopped.\"}",
+      "Timestamp": "2019-02-12T15:45:24.091Z",
+      "SignatureVersion": "1",
+      "Signature": "EXAMPLE",
+      "SigningCertUrl": "EXAMPLE",
+      "UnsubscribeUrl": "EXAMPLE",
+      "MessageAttributes": {}
+    }
+  }]
+}

--- a/aws/aws-notify-slack/functions/messages/glue_notification.json
+++ b/aws/aws-notify-slack/functions/messages/glue_notification.json
@@ -1,0 +1,20 @@
+{
+  "Records": [{
+    "EventSource": "aws:sns",
+    "EventVersion": "1.0",
+    "EventSubscriptionArn": "arn:aws:sns:us-east-2::ExampleTopic",
+    "Sns": {
+      "Type": "Notification",
+      "MessageId": "00337b3f-0982-5cb1-9138-22799c885da9",
+      "TopicArn": "arn:aws:sns:us-east-2:123456789012:ExampleTopic",
+      "Subject": "",
+      "Message": "{\"version\": \"0\",\"id\": \"ad3c3da1-148c-d5da-9a6a-79f1bc9a8a2e\",\"detail-type\": \"Glue Job State Change\",\"source\": \"aws.glue\",\"account\": \"000000000000\",\"time\": \"2021-06-18T12:34:06Z\",\"region\": \"us-east-2\",\"resources\": [],\"detail\": {\"jobName\": \"test_job\",\"severity\": \"ERROR\",\"state\": \"FAILED\",\"jobRunId\": \"jr_ca2144d747b45ad412d3c66a1b6934b6b27aa252be9a21a95c54dfaa224a1925\",\"message\": \"SystemExit: 1\"}}",
+      "Timestamp": "2021-06-18T12:34:09.509Z",
+      "SignatureVersion": "1",
+      "Signature": "EXAMPLE",
+      "SigningCertUrl": "EXAMPLE",
+      "UnsubscribeUrl": "EXAMPLE",
+      "MessageAttributes": {}
+    }
+  }]
+}

--- a/aws/aws-notify-slack/functions/messages/guardduty_finding.json
+++ b/aws/aws-notify-slack/functions/messages/guardduty_finding.json
@@ -1,0 +1,20 @@
+{
+  "Records": [{
+    "EventSource": "aws:sns",
+    "EventVersion": "1.0",
+    "EventSubscriptionArn": "arn:aws:sns:us-gov-east-1::ExampleTopic",
+    "Sns": {
+      "Type": "Notification",
+      "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+      "TopicArn": "arn:aws:sns:us-gov-east-1:123456789012:ExampleTopic",
+      "Subject": "GuardDuty Finding",
+      "Message": "{\"detail-type\": \"GuardDuty Finding\",\"region\": \"us-gov-east-1\",\"detail\": {\"id\": \"sample-id-2\",\"title\": \"SAMPLE Unprotected port on EC2 instance i-123123123 is being probed\",\"severity\": 9,\"accountId\":\"123456789\",\"description\": \"EC2 instance has an unprotected port which is being probed by a known malicious host.\",\"type\": \"Recon:EC2 PortProbeUnprotectedPort\",\"service\": {\"eventFirstSeen\": \"2020-01-02T01:02:03Z\",\"eventLastSeen\": \"2020-01-03T01:02:03Z\",\"count\": 1234}}}",
+      "Timestamp": "1970-01-01T00:00:00.000Z",
+      "SignatureVersion": "1",
+      "Signature": "EXAMPLE",
+      "SigningCertUrl": "EXAMPLE",
+      "UnsubscribeUrl": "EXAMPLE",
+      "MessageAttributes": {}
+    }
+  }]
+}

--- a/aws/aws-notify-slack/functions/messages/text_message.json
+++ b/aws/aws-notify-slack/functions/messages/text_message.json
@@ -1,0 +1,20 @@
+{
+  "Records": [{
+    "EventSource": "aws:sns",
+    "EventVersion": "1.0",
+    "EventSubscriptionArn": "arn:aws:sns:us-gov-west-1::ExampleTopic",
+    "Sns": {
+      "Type": "Notification",
+      "MessageId": "f86e3c5b-cd17-1ab8-80e9-c0776d4f1e7a",
+      "TopicArn": "arn:aws:sns:us-gov-west-1:123456789012:ExampleTopic",
+      "Subject": "All Fine",
+      "Message": "This\nis\na typical multi-line\nmessage from SNS!\n\nHave a ~good~ amazing day! :)",
+      "Timestamp": "2019-02-12T15:45:24.091Z",
+      "SignatureVersion": "1",
+      "Signature": "EXAMPLE",
+      "SigningCertUrl": "EXAMPLE",
+      "UnsubscribeUrl": "EXAMPLE",
+      "MessageAttributes": {}
+    }
+  }]
+}

--- a/aws/aws-notify-slack/functions/mylambda.py
+++ b/aws/aws-notify-slack/functions/mylambda.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3.6
+# CUSTOM LAMBDA FUNCTION
+
+import json
+import os
+
+import urllib3
+
+http = urllib3.PoolManager()
+
+
+def lambda_handler(event, context):
+    url = os.environ["SLACK_WEBHOOK_URL"]
+    msg = {
+        "channel": "#channel-name",
+        "username": "Prometheus",
+        "text": event["Records"][0]["Sns"]["Message"],
+        "icon_emoji": "",
+    }
+
+    encoded_msg = json.dumps(msg).encode("utf-8")
+    resp = http.request("POST", url, body=encoded_msg)
+    print(
+        {
+            "message": event["Records"][0]["Sns"]["Message"],
+            "status_code": resp.status,
+            "response": resp.data,
+        }
+    )

--- a/aws/aws-notify-slack/functions/notify_slack.py
+++ b/aws/aws-notify-slack/functions/notify_slack.py
@@ -1,0 +1,411 @@
+# -*- coding: utf-8 -*-
+"""
+    Notify Slack
+    ------------
+
+    Receives event payloads that are parsed and sent to Slack
+
+"""
+
+import base64
+import json
+import logging
+import os
+import urllib.parse
+import urllib.request
+from enum import Enum
+from typing import Any, Dict, Optional, Union, cast
+from urllib.error import HTTPError
+
+import boto3
+
+# Set default region if not provided
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+# Create client so its cached/frozen between invocations
+KMS_CLIENT = boto3.client("kms", region_name=REGION)
+
+
+class AwsService(Enum):
+    """AWS service supported by function"""
+
+    cloudwatch = "cloudwatch"
+    guardduty = "guardduty"
+
+
+def decrypt_url(encrypted_url: str) -> str:
+    """Decrypt encrypted URL with KMS
+
+    :param encrypted_url: URL to decrypt with KMS
+    :returns: plaintext URL
+    """
+    try:
+        decrypted_payload = KMS_CLIENT.decrypt(
+            CiphertextBlob=base64.b64decode(encrypted_url)
+        )
+        return decrypted_payload["Plaintext"].decode()
+    except Exception:
+        logging.exception("Failed to decrypt URL with KMS")
+        return ""
+
+
+def get_service_url(region: str, service: str) -> str:
+    """Get the appropriate service URL for the region
+
+    :param region: name of the AWS region
+    :param service: name of the AWS service
+    :returns: AWS console url formatted for the region and service provided
+    """
+    try:
+        service_name = AwsService[service].value
+        if region.startswith("us-gov-"):
+            return f"https://console.amazonaws-us-gov.com/{service_name}/home?region={region}"
+        else:
+            return f"https://console.aws.amazon.com/{service_name}/home?region={region}"
+
+    except KeyError:
+        print(f"Service {service} is currently not supported")
+        raise
+
+
+class CloudWatchAlarmState(Enum):
+    """Maps CloudWatch notification state to Slack message format color"""
+
+    OK = "good"
+    INSUFFICIENT_DATA = "warning"
+    ALARM = "danger"
+
+
+def format_cloudwatch_alarm(message: Dict[str, Any], region: str) -> Dict[str, Any]:
+    """Format CloudWatch alarm event into Slack message format
+
+    :params message: SNS message body containing CloudWatch alarm event
+    :region: AWS region where the event originated from
+    :returns: formatted Slack message payload
+    """
+
+    cloudwatch_url = get_service_url(region=region, service="cloudwatch")
+    alarm_name = message["AlarmName"]
+
+    return {
+        "color": CloudWatchAlarmState[message["NewStateValue"]].value,
+        "fallback": f"Alarm {alarm_name} triggered",
+        "fields": [
+            {"title": "Alarm Name", "value": f"`{alarm_name}`", "short": True},
+            {
+                "title": "Alarm Description",
+                "value": f"`{message['AlarmDescription']}`",
+                "short": False,
+            },
+            {
+                "title": "Alarm reason",
+                "value": f"`{message['NewStateReason']}`",
+                "short": False,
+            },
+            {
+                "title": "Old State",
+                "value": f"`{message['OldStateValue']}`",
+                "short": True,
+            },
+            {
+                "title": "Current State",
+                "value": f"`{message['NewStateValue']}`",
+                "short": True,
+            },
+            {
+                "title": "Link to Alarm",
+                "value": f"{cloudwatch_url}#alarm:alarmFilter=ANY;name={urllib.parse.quote(alarm_name)}",
+                "short": False,
+            },
+        ],
+        "text": f"AWS CloudWatch notification - {message['AlarmName']}",
+    }
+
+
+class GuardDutyFindingSeverity(Enum):
+    """Maps GuardDuty finding severity to Slack message format color"""
+
+    Low = "#777777"
+    Medium = "warning"
+    High = "danger"
+
+
+def format_guardduty_finding(message: Dict[str, Any], region: str) -> Dict[str, Any]:
+    """
+    Format GuardDuty finding event into Slack message format
+
+    :params message: SNS message body containing GuardDuty finding event
+    :params region: AWS region where the event originated from
+    :returns: formatted Slack message payload
+    """
+
+    guardduty_url = get_service_url(region=region, service="guardduty")
+    detail = message["detail"]
+    service = detail.get("service", {})
+    severity_score = detail.get("severity")
+
+    if severity_score < 4.0:
+        severity = "Low"
+    elif severity_score < 7.0:
+        severity = "Medium"
+    else:
+        severity = "High"
+
+    return {
+        "color": GuardDutyFindingSeverity[severity].value,
+        "fallback": f"GuardDuty Finding: {detail.get('title')}",
+        "fields": [
+            {
+                "title": "Description",
+                "value": f"`{detail['description']}`",
+                "short": False,
+            },
+            {
+                "title": "Finding Type",
+                "value": f"`{detail['type']}`",
+                "short": False,
+            },
+            {
+                "title": "First Seen",
+                "value": f"`{service['eventFirstSeen']}`",
+                "short": True,
+            },
+            {
+                "title": "Last Seen",
+                "value": f"`{service['eventLastSeen']}`",
+                "short": True,
+            },
+            {"title": "Severity", "value": f"`{severity}`", "short": True},
+            {"title": "Account ID", "value": f"`{detail['accountId']}`", "short": True},
+            {
+                "title": "Count",
+                "value": f"`{service['count']}`",
+                "short": True,
+            },
+            {
+                "title": "Link to Finding",
+                "value": f"{guardduty_url}#/findings?search=id%3D{detail['id']}",
+                "short": False,
+            },
+        ],
+        "text": f"AWS GuardDuty Finding - {detail.get('title')}",
+    }
+
+
+class AwsHealthCategory(Enum):
+    """Maps AWS Health eventTypeCategory to Slack message format color
+
+    eventTypeCategory
+        The category code of the event. The possible values are issue,
+        accountNotification, and scheduledChange.
+    """
+
+    accountNotification = "#777777"
+    scheduledChange = "warning"
+    issue = "danger"
+
+
+def format_aws_health(message: Dict[str, Any], region: str) -> Dict[str, Any]:
+    """
+    Format AWS Health event into Slack message format
+
+    :params message: SNS message body containing AWS Health event
+    :params region: AWS region where the event originated from
+    :returns: formatted Slack message payload
+    """
+
+    aws_health_url = (
+        f"https://phd.aws.amazon.com/phd/home?region={region}#/dashboard/open-issues"
+    )
+    detail = message["detail"]
+    resources = message.get("resources", "<unknown>")
+    service = detail.get("service", "<unknown>")
+
+    return {
+        "color": AwsHealthCategory[detail["eventTypeCategory"]].value,
+        "text": f"New AWS Health Event for {service}",
+        "fallback": f"New AWS Health Event for {service}",
+        "fields": [
+            {"title": "Affected Service", "value": f"`{service}`", "short": True},
+            {
+                "title": "Affected Region",
+                "value": f"`{message.get('region')}`",
+                "short": True,
+            },
+            {
+                "title": "Code",
+                "value": f"`{detail.get('eventTypeCode')}`",
+                "short": False,
+            },
+            {
+                "title": "Event Description",
+                "value": f"`{detail['eventDescription'][0]['latestDescription']}`",
+                "short": False,
+            },
+            {
+                "title": "Affected Resources",
+                "value": f"`{', '.join(resources)}`",
+                "short": False,
+            },
+            {
+                "title": "Start Time",
+                "value": f"`{detail.get('startTime', '<unknown>')}`",
+                "short": True,
+            },
+            {
+                "title": "End Time",
+                "value": f"`{detail.get('endTime', '<unknown>')}`",
+                "short": True,
+            },
+            {
+                "title": "Link to Event",
+                "value": f"{aws_health_url}",
+                "short": False,
+            },
+        ],
+    }
+
+
+def format_default(
+    message: Union[str, Dict], subject: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    Default formatter, converting event into Slack message format
+
+    :params message: SNS message body containing message/event
+    :returns: formatted Slack message payload
+    """
+
+    attachments = {
+        "fallback": "A new message",
+        "text": "AWS notification",
+        "title": subject if subject else "Message",
+        "mrkdwn_in": ["value"],
+    }
+    fields = []
+
+    if type(message) is dict:
+        for k, v in message.items():
+            value = f"{json.dumps(v)}" if isinstance(v, (dict, list)) else str(v)
+            fields.append({"title": k, "value": f"`{value}`", "short": len(value) < 25})
+    else:
+        fields.append({"value": message, "short": False})
+
+    if fields:
+        attachments["fields"] = fields  # type: ignore
+
+    return attachments
+
+
+def get_slack_message_payload(
+    message: Union[str, Dict], region: str, subject: Optional[str] = None
+) -> Dict:
+    """
+    Parse notification message and format into Slack message payload
+
+    :params message: SNS message body notification payload
+    :params region: AWS region where the event originated from
+    :params subject: Optional subject line for Slack notification
+    :returns: Slack message payload
+    """
+
+    slack_channel = os.environ["SLACK_CHANNEL"]
+    slack_username = os.environ["SLACK_USERNAME"]
+    slack_emoji = os.environ["SLACK_EMOJI"]
+
+    payload = {
+        "channel": slack_channel,
+        "username": slack_username,
+        "icon_emoji": slack_emoji
+    }
+    attachment = None
+
+    if isinstance(message, str):
+        try:
+            message = json.loads(message)
+        except json.JSONDecodeError:
+            logging.info("Not a structured payload, just a string message")
+
+    message = cast(Dict[str, Any], message)
+
+    if "AlarmName" in message:
+        notification = format_cloudwatch_alarm(message=message, region=region)
+        attachment = notification
+
+    elif (
+        isinstance(message, Dict) and message.get("detail-type") == "GuardDuty Finding"
+    ):
+        notification = format_guardduty_finding(
+            message=message, region=message["region"]
+        )
+        attachment = notification
+
+    elif isinstance(message, Dict) and message.get("detail-type") == "AWS Health Event":
+        notification = format_aws_health(message=message, region=message["region"])
+        attachment = notification
+
+    elif "attachments" in message or "text" in message:
+        payload = {**payload, **message}
+
+    else:
+        attachment = format_default(message=message, subject=subject)
+
+    if attachment:
+        payload["attachments"] = [attachment]  # type: ignore
+
+    return payload
+
+
+def send_slack_notification(payload: Dict[str, Any]) -> str:
+    """
+    Send notification payload to Slack
+
+    :params payload: formatted Slack message payload
+    :returns: response details from sending notification
+    """
+
+    slack_url = os.environ["SLACK_WEBHOOK_URL"]
+    if not slack_url.startswith("http"):
+        slack_url = decrypt_url(slack_url)
+
+    data = urllib.parse.urlencode({"payload": json.dumps(payload)}).encode("utf-8")
+    req = urllib.request.Request(slack_url)
+
+    try:
+        result = urllib.request.urlopen(req, data)
+        return json.dumps({"code": result.getcode(), "info": result.info().as_string()})
+
+    except HTTPError as e:
+        logging.error(f"{e}: result")
+        return json.dumps({"code": e.getcode(), "info": e.info().as_string()})
+
+
+def lambda_handler(event: Dict[str, Any], context: Dict[str, Any]) -> str:
+    """
+    Lambda function to parse notification events and forward to Slack
+
+    :param event: lambda expected event object
+    :param context: lambda expected context object
+    :returns: none
+    """
+    if os.environ.get("LOG_EVENTS", "False") == "True":
+        logging.info(f"Event logging enabled: `{json.dumps(event)}`")
+
+    for record in event["Records"]:
+        sns = record["Sns"]
+        subject = sns["Subject"]
+        message = sns["Message"]
+        region = sns["TopicArn"].split(":")[3]
+
+        payload = get_slack_message_payload(
+            message=message, region=region, subject=subject
+        )
+        response = send_slack_notification(payload=payload)
+
+    if json.loads(response)["code"] != 200:
+        response_info = json.loads(response)["info"]
+        logging.error(
+            f"Error: received status `{response_info}` using event `{event}` and context `{context}`"
+        )
+
+    return response

--- a/aws/aws-notify-slack/functions/notify_slack_test.py
+++ b/aws/aws-notify-slack/functions/notify_slack_test.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+"""
+    Slack Notification Test
+    -----------------------
+
+    Unit tests for `notify_slack.py`
+
+"""
+
+import ast
+import os
+
+import notify_slack
+import pytest
+
+
+def test_sns_get_slack_message_payload_snapshots(snapshot, monkeypatch):
+    """
+    Compare outputs of get_slack_message_payload() with snapshots stored
+
+    Run `pipenv run test:updatesnapshots` to update snapshot images
+    """
+
+    monkeypatch.setenv("SLACK_CHANNEL", "slack_testing_sandbox")
+    monkeypatch.setenv("SLACK_USERNAME", "notify_slack_test")
+    monkeypatch.setenv("SLACK_EMOJI", ":aws:")
+
+    # These are SNS messages that invoke the lambda handler; the event payload is in the
+    # `message` field
+    _dir = "./messages"
+    messages = [f for f in os.listdir(_dir) if os.path.isfile(os.path.join(_dir, f))]
+
+    for file in messages:
+        with open(os.path.join(_dir, file), "r") as ofile:
+            event = ast.literal_eval(ofile.read())
+
+            attachments = []
+            # These are as delivered wrapped in an SNS message payload so we unpack
+            for record in event["Records"]:
+                sns = record["Sns"]
+                subject = sns["Subject"]
+                message = sns["Message"]
+                region = sns["TopicArn"].split(":")[3]
+
+                attachment = notify_slack.get_slack_message_payload(
+                    message=message, region=region, subject=subject
+                )
+                attachments.append(attachment)
+
+            filename = os.path.basename(file)
+            snapshot.assert_match(attachments, f"message_{filename}")
+
+
+def test_event_get_slack_message_payload_snapshots(snapshot, monkeypatch):
+    """
+    Compare outputs of get_slack_message_payload() with snapshots stored
+
+    Run `pipenv run test:updatesnapshots` to update snapshot images
+    """
+
+    monkeypatch.setenv("SLACK_CHANNEL", "slack_testing_sandbox")
+    monkeypatch.setenv("SLACK_USERNAME", "notify_slack_test")
+    monkeypatch.setenv("SLACK_EMOJI", ":aws:")
+
+    # These are just the raw events that will be converted to JSON string and
+    # sent via SNS message
+    _dir = "./events"
+    events = [f for f in os.listdir(_dir) if os.path.isfile(os.path.join(_dir, f))]
+
+    for file in events:
+        with open(os.path.join(_dir, file), "r") as ofile:
+            event = ast.literal_eval(ofile.read())
+
+            attachment = notify_slack.get_slack_message_payload(
+                message=event, region="us-east-1", subject="bar"
+            )
+            attachments = [attachment]
+
+            filename = os.path.basename(file)
+            snapshot.assert_match(attachments, f"event_{filename}")
+
+
+def test_environment_variables_set(monkeypatch):
+    """
+    Should pass since environment variables are provided
+    """
+
+    monkeypatch.setenv("SLACK_CHANNEL", "slack_testing_sandbox")
+    monkeypatch.setenv("SLACK_USERNAME", "notify_slack_test")
+    monkeypatch.setenv("SLACK_EMOJI", ":aws:")
+    monkeypatch.setenv(
+        "SLACK_WEBHOOK_URL", "https://hooks.slack.com/services/YOUR/WEBOOK/URL"
+    )
+
+    with open(os.path.join("./messages/text_message.json"), "r") as efile:
+        event = ast.literal_eval(efile.read())
+
+        for record in event["Records"]:
+            sns = record["Sns"]
+            subject = sns["Subject"]
+            message = sns["Message"]
+            region = sns["TopicArn"].split(":")[3]
+
+            notify_slack.get_slack_message_payload(
+                message=message, region=region, subject=subject
+            )
+
+
+def test_environment_variables_missing():
+    """
+    Should pass since environment variables are NOT provided and
+    will raise a `KeyError`
+    """
+    with pytest.raises(KeyError):
+        # will raise before parsing/validation
+        notify_slack.get_slack_message_payload(message={}, region="foo", subject="bar")
+
+
+@pytest.mark.parametrize(
+    "region,service,expected",
+    [
+        (
+            "us-east-1",
+            "cloudwatch",
+            "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1",
+        ),
+        (
+            "us-gov-east-1",
+            "cloudwatch",
+            "https://console.amazonaws-us-gov.com/cloudwatch/home?region=us-gov-east-1",
+        ),
+        (
+            "us-east-1",
+            "guardduty",
+            "https://console.aws.amazon.com/guardduty/home?region=us-east-1",
+        ),
+        (
+            "us-gov-east-1",
+            "guardduty",
+            "https://console.amazonaws-us-gov.com/guardduty/home?region=us-gov-east-1",
+        ),
+    ],
+)
+def test_get_service_url(region, service, expected):
+    assert notify_slack.get_service_url(region=region, service=service) == expected
+
+
+def test_get_service_url_exception():
+    """
+    Should raise error since service is not defined in enum
+    """
+    with pytest.raises(KeyError):
+        notify_slack.get_service_url(region="us-east-1", service="athena")

--- a/aws/aws-notify-slack/functions/snapshots/snap_notify_slack_test.py
+++ b/aws/aws-notify-slack/functions/snapshots/snap_notify_slack_test.py
@@ -1,0 +1,434 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+snapshots = Snapshot()
+
+snapshots[
+    "test_event_get_slack_message_payload_snapshots event_aws_health_event.json"
+] = [
+    {
+        "attachments": [
+            {
+                "color": "danger",
+                "fallback": "New AWS Health Event for EC2",
+                "fields": [
+                    {"short": True, "title": "Affected Service", "value": "`EC2`"},
+                    {"short": True, "title": "Affected Region", "value": "`us-west-2`"},
+                    {
+                        "short": False,
+                        "title": "Code",
+                        "value": "`AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED`",
+                    },
+                    {
+                        "short": False,
+                        "title": "Event Description",
+                        "value": "`A description of the event will be provided here`",
+                    },
+                    {
+                        "short": False,
+                        "title": "Affected Resources",
+                        "value": "`i-abcd1111`",
+                    },
+                    {
+                        "short": True,
+                        "title": "Start Time",
+                        "value": "`Sat, 05 Jun 2016 15:10:09 GMT`",
+                    },
+                    {"short": True, "title": "End Time", "value": "`<unknown>`"},
+                    {
+                        "short": False,
+                        "title": "Link to Event",
+                        "value": "https://phd.aws.amazon.com/phd/home?region=us-west-2#/dashboard/open-issues",
+                    },
+                ],
+                "text": "New AWS Health Event for EC2",
+            }
+        ],
+        "channel": "slack_testing_sandbox",
+        "icon_emoji": ":aws:",
+        "username": "notify_slack_test",
+    }
+]
+
+snapshots[
+    "test_event_get_slack_message_payload_snapshots event_cloudwatch_alarm.json"
+] = [
+    {
+        "attachments": [
+            {
+                "color": "danger",
+                "fallback": "Alarm Example triggered",
+                "fields": [
+                    {"short": True, "title": "Alarm Name", "value": "`Example`"},
+                    {
+                        "short": False,
+                        "title": "Alarm Description",
+                        "value": "`Example alarm description.`",
+                    },
+                    {
+                        "short": False,
+                        "title": "Alarm reason",
+                        "value": "`Threshold Crossed`",
+                    },
+                    {"short": True, "title": "Old State", "value": "`OK`"},
+                    {"short": True, "title": "Current State", "value": "`ALARM`"},
+                    {
+                        "short": False,
+                        "title": "Link to Alarm",
+                        "value": "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY;name=Example",
+                    },
+                ],
+                "text": "AWS CloudWatch notification - Example",
+            }
+        ],
+        "channel": "slack_testing_sandbox",
+        "icon_emoji": ":aws:",
+        "username": "notify_slack_test",
+    }
+]
+
+snapshots[
+    "test_event_get_slack_message_payload_snapshots event_guardduty_finding_high.json"
+] = [
+    {
+        "attachments": [
+            {
+                "color": "danger",
+                "fallback": "GuardDuty Finding: SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
+                "fields": [
+                    {
+                        "short": False,
+                        "title": "Description",
+                        "value": "`EC2 instance has an unprotected port which is being probed by a known malicious host.`",
+                    },
+                    {
+                        "short": False,
+                        "title": "Finding Type",
+                        "value": "`Recon:EC2 PortProbeUnprotectedPort`",
+                    },
+                    {
+                        "short": True,
+                        "title": "First Seen",
+                        "value": "`2020-01-02T01:02:03Z`",
+                    },
+                    {
+                        "short": True,
+                        "title": "Last Seen",
+                        "value": "`2020-01-03T01:02:03Z`",
+                    },
+                    {"short": True, "title": "Severity", "value": "`High`"},
+                    {"short": True, "title": "Account ID", "value": "`123456789`"},
+                    {"short": True, "title": "Count", "value": "`1234`"},
+                    {
+                        "short": False,
+                        "title": "Link to Finding",
+                        "value": "https://console.aws.amazon.com/guardduty/home?region=us-east-1#/findings?search=id%3Dsample-id-2",
+                    },
+                ],
+                "text": "AWS GuardDuty Finding - SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
+            }
+        ],
+        "channel": "slack_testing_sandbox",
+        "icon_emoji": ":aws:",
+        "username": "notify_slack_test",
+    }
+]
+
+snapshots[
+    "test_event_get_slack_message_payload_snapshots event_guardduty_finding_low.json"
+] = [
+    {
+        "attachments": [
+            {
+                "color": "#777777",
+                "fallback": "GuardDuty Finding: SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
+                "fields": [
+                    {
+                        "short": False,
+                        "title": "Description",
+                        "value": "`EC2 instance has an unprotected port which is being probed by a known malicious host.`",
+                    },
+                    {
+                        "short": False,
+                        "title": "Finding Type",
+                        "value": "`Recon:EC2 PortProbeUnprotectedPort`",
+                    },
+                    {
+                        "short": True,
+                        "title": "First Seen",
+                        "value": "`2020-01-02T01:02:03Z`",
+                    },
+                    {
+                        "short": True,
+                        "title": "Last Seen",
+                        "value": "`2020-01-03T01:02:03Z`",
+                    },
+                    {"short": True, "title": "Severity", "value": "`Low`"},
+                    {"short": True, "title": "Account ID", "value": "`123456789`"},
+                    {"short": True, "title": "Count", "value": "`1234`"},
+                    {
+                        "short": False,
+                        "title": "Link to Finding",
+                        "value": "https://console.aws.amazon.com/guardduty/home?region=us-east-1#/findings?search=id%3Dsample-id-2",
+                    },
+                ],
+                "text": "AWS GuardDuty Finding - SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
+            }
+        ],
+        "channel": "slack_testing_sandbox",
+        "icon_emoji": ":aws:",
+        "username": "notify_slack_test",
+    }
+]
+
+snapshots[
+    "test_event_get_slack_message_payload_snapshots event_guardduty_finding_medium.json"
+] = [
+    {
+        "attachments": [
+            {
+                "color": "warning",
+                "fallback": "GuardDuty Finding: SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
+                "fields": [
+                    {
+                        "short": False,
+                        "title": "Description",
+                        "value": "`EC2 instance has an unprotected port which is being probed by a known malicious host.`",
+                    },
+                    {
+                        "short": False,
+                        "title": "Finding Type",
+                        "value": "`Recon:EC2 PortProbeUnprotectedPort`",
+                    },
+                    {
+                        "short": True,
+                        "title": "First Seen",
+                        "value": "`2020-01-02T01:02:03Z`",
+                    },
+                    {
+                        "short": True,
+                        "title": "Last Seen",
+                        "value": "`2020-01-03T01:02:03Z`",
+                    },
+                    {"short": True, "title": "Severity", "value": "`Medium`"},
+                    {"short": True, "title": "Account ID", "value": "`123456789`"},
+                    {"short": True, "title": "Count", "value": "`1234`"},
+                    {
+                        "short": False,
+                        "title": "Link to Finding",
+                        "value": "https://console.aws.amazon.com/guardduty/home?region=us-east-1#/findings?search=id%3Dsample-id-2",
+                    },
+                ],
+                "text": "AWS GuardDuty Finding - SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
+            }
+        ],
+        "channel": "slack_testing_sandbox",
+        "icon_emoji": ":aws:",
+        "username": "notify_slack_test",
+    }
+]
+
+snapshots[
+    "test_sns_get_slack_message_payload_snapshots message_cloudwatch_alarm.json"
+] = [
+    {
+        "attachments": [
+            {
+                "color": "good",
+                "fallback": "Alarm DBMigrationRequired triggered",
+                "fields": [
+                    {
+                        "short": True,
+                        "title": "Alarm Name",
+                        "value": "`DBMigrationRequired`",
+                    },
+                    {
+                        "short": False,
+                        "title": "Alarm Description",
+                        "value": '`App is reporting "A JPA error occurred(Unable to build EntityManagerFactory)"`',
+                    },
+                    {
+                        "short": False,
+                        "title": "Alarm reason",
+                        "value": "`Threshold Crossed: 1 datapoint [1.0 (12/02/19 15:44:00)] was not less than the threshold (1.0).`",
+                    },
+                    {"short": True, "title": "Old State", "value": "`ALARM`"},
+                    {"short": True, "title": "Current State", "value": "`OK`"},
+                    {
+                        "short": False,
+                        "title": "Link to Alarm",
+                        "value": "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:alarmFilter=ANY;name=DBMigrationRequired",
+                    },
+                ],
+                "text": "AWS CloudWatch notification - DBMigrationRequired",
+            }
+        ],
+        "channel": "slack_testing_sandbox",
+        "icon_emoji": ":aws:",
+        "username": "notify_slack_test",
+    }
+]
+
+snapshots[
+    "test_sns_get_slack_message_payload_snapshots message_dms_notification.json"
+] = [
+    {
+        "attachments": [
+            {
+                "fallback": "A new message",
+                "fields": [
+                    {
+                        "short": True,
+                        "title": "Event Source",
+                        "value": "`replication-task`",
+                    },
+                    {
+                        "short": True,
+                        "title": "Event Time",
+                        "value": "`2019-02-12 15:45:24.091`",
+                    },
+                    {
+                        "short": False,
+                        "title": "Identifier Link",
+                        "value": "`https://console.aws.amazon.com/dms/home?region=us-east-1#tasks:ids=hello-world`",
+                    },
+                    {"short": True, "title": "SourceId", "value": "`hello-world`"},
+                    {
+                        "short": False,
+                        "title": "Event ID",
+                        "value": "`http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Events.html#DMS-EVENT-0079 `",
+                    },
+                    {
+                        "short": False,
+                        "title": "Event Message",
+                        "value": "`Replication task has stopped.`",
+                    },
+                ],
+                "mrkdwn_in": ["value"],
+                "text": "AWS notification",
+                "title": "DMS Notification Message",
+            }
+        ],
+        "channel": "slack_testing_sandbox",
+        "icon_emoji": ":aws:",
+        "username": "notify_slack_test",
+    }
+]
+
+snapshots[
+    "test_sns_get_slack_message_payload_snapshots message_glue_notification.json"
+] = [
+    {
+        "attachments": [
+            {
+                "fallback": "A new message",
+                "fields": [
+                    {"short": True, "title": "version", "value": "`0`"},
+                    {
+                        "short": False,
+                        "title": "id",
+                        "value": "`ad3c3da1-148c-d5da-9a6a-79f1bc9a8a2e`",
+                    },
+                    {
+                        "short": True,
+                        "title": "detail-type",
+                        "value": "`Glue Job State Change`",
+                    },
+                    {"short": True, "title": "source", "value": "`aws.glue`"},
+                    {"short": True, "title": "account", "value": "`000000000000`"},
+                    {"short": True, "title": "time", "value": "`2021-06-18T12:34:06Z`"},
+                    {"short": True, "title": "region", "value": "`us-east-2`"},
+                    {"short": True, "title": "resources", "value": "`[]`"},
+                    {
+                        "short": False,
+                        "title": "detail",
+                        "value": '`{"jobName": "test_job", "severity": "ERROR", "state": "FAILED", "jobRunId": "jr_ca2144d747b45ad412d3c66a1b6934b6b27aa252be9a21a95c54dfaa224a1925", "message": "SystemExit: 1"}`',
+                    },
+                ],
+                "mrkdwn_in": ["value"],
+                "text": "AWS notification",
+                "title": "Message",
+            }
+        ],
+        "channel": "slack_testing_sandbox",
+        "icon_emoji": ":aws:",
+        "username": "notify_slack_test",
+    }
+]
+
+snapshots[
+    "test_sns_get_slack_message_payload_snapshots message_guardduty_finding.json"
+] = [
+    {
+        "attachments": [
+            {
+                "color": "danger",
+                "fallback": "GuardDuty Finding: SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
+                "fields": [
+                    {
+                        "short": False,
+                        "title": "Description",
+                        "value": "`EC2 instance has an unprotected port which is being probed by a known malicious host.`",
+                    },
+                    {
+                        "short": False,
+                        "title": "Finding Type",
+                        "value": "`Recon:EC2 PortProbeUnprotectedPort`",
+                    },
+                    {
+                        "short": True,
+                        "title": "First Seen",
+                        "value": "`2020-01-02T01:02:03Z`",
+                    },
+                    {
+                        "short": True,
+                        "title": "Last Seen",
+                        "value": "`2020-01-03T01:02:03Z`",
+                    },
+                    {"short": True, "title": "Severity", "value": "`High`"},
+                    {"short": True, "title": "Account ID", "value": "`123456789`"},
+                    {"short": True, "title": "Count", "value": "`1234`"},
+                    {
+                        "short": False,
+                        "title": "Link to Finding",
+                        "value": "https://console.amazonaws-us-gov.com/guardduty/home?region=us-gov-east-1#/findings?search=id%3Dsample-id-2",
+                    },
+                ],
+                "text": "AWS GuardDuty Finding - SAMPLE Unprotected port on EC2 instance i-123123123 is being probed",
+            }
+        ],
+        "channel": "slack_testing_sandbox",
+        "icon_emoji": ":aws:",
+        "username": "notify_slack_test",
+    }
+]
+
+snapshots["test_sns_get_slack_message_payload_snapshots message_text_message.json"] = [
+    {
+        "attachments": [
+            {
+                "fallback": "A new message",
+                "fields": [
+                    {
+                        "short": False,
+                        "value": """This
+is
+a typical multi-line
+message from SNS!
+
+Have a ~good~ amazing day! :)""",
+                    }
+                ],
+                "mrkdwn_in": ["value"],
+                "text": "AWS notification",
+                "title": "All Fine",
+            }
+        ],
+        "channel": "slack_testing_sandbox",
+        "icon_emoji": ":aws:",
+        "username": "notify_slack_test",
+    }
+]

--- a/aws/aws-notify-slack/iam.tf
+++ b/aws/aws-notify-slack/iam.tf
@@ -1,0 +1,50 @@
+locals {
+  create_sns_feedback_role = local.create && var.create_sns_topic && var.enable_sns_topic_delivery_status_logs && var.sns_topic_lambda_feedback_role_arn == ""
+}
+
+# data "aws_iam_policy_document" "sns_feedback" {
+#   count = local.create_sns_feedback_role ? 1 : 0
+#
+#   statement {
+#     sid    = "PermitDeliveryStatusMessagesToCloudWatchLogs"
+#     effect = "Allow"
+#
+#     actions = [
+#       "logs:CreateLogGroup",
+#       "logs:CreateLogStream",
+#       "logs:PutLogEvents",
+#       "logs:PutMetricFilter",
+#       "logs:PutRetentionPolicy"
+#     ]
+#
+#     resources = [
+#       "*"
+#     ]
+#   }
+# }
+
+resource "aws_iam_role" "sns_feedback_role" {
+  count = local.create_sns_feedback_role ? 1 : 0
+
+  name                  = var.sns_topic_feedback_role_name
+  description           = var.sns_topic_feedback_role_description
+  path                  = var.sns_topic_feedback_role_path
+  force_detach_policies = var.sns_topic_feedback_role_force_detach_policies
+  permissions_boundary  = var.sns_topic_feedback_role_permissions_boundary
+  # assume_role_policy    = data.aws_iam_policy_document.sns_feedback[0].json
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "sns.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  tags = merge(var.tags, var.sns_topic_feedback_role_tags)
+}

--- a/aws/aws-notify-slack/main.tf
+++ b/aws/aws-notify-slack/main.tf
@@ -1,0 +1,148 @@
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+
+locals {
+  create = var.create && var.putin_khuylo
+
+  sns_topic_arn = try(
+    aws_sns_topic.this[0].arn,
+    "arn:${data.aws_partition.current.id}:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${var.sns_topic_name}",
+    ""
+  )
+
+  sns_feedback_role = local.create_sns_feedback_role ? aws_iam_role.sns_feedback_role[0].arn : var.sns_topic_lambda_feedback_role_arn
+  lambda_policy_document = {
+    sid       = "AllowWriteToCloudwatchLogs"
+    effect    = "Allow"
+    actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = [replace("${try(aws_cloudwatch_log_group.lambda[0].arn, "")}:*", ":*:*", ":*")]
+  }
+
+  lambda_policy_document_kms = {
+    sid       = "AllowKMSDecrypt"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = [var.kms_key_arn]
+  }
+
+  lambda_handler = try(split(".", basename(var.lambda_source_path))[0], "notify_slack")
+}
+
+data "aws_iam_policy_document" "lambda" {
+  count = var.create ? 1 : 0
+
+  dynamic "statement" {
+    for_each = concat([local.lambda_policy_document], var.kms_key_arn != "" ? [local.lambda_policy_document_kms] : [])
+    content {
+      sid       = statement.value.sid
+      effect    = statement.value.effect
+      actions   = statement.value.actions
+      resources = statement.value.resources
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  count = var.create ? 1 : 0
+
+  name              = "/aws/lambda/${var.lambda_function_name}"
+  retention_in_days = var.cloudwatch_log_group_retention_in_days
+  kms_key_id        = var.cloudwatch_log_group_kms_key_id
+
+  tags = merge(var.tags, var.cloudwatch_log_group_tags)
+}
+
+resource "aws_sns_topic" "this" {
+  count = var.create_sns_topic && var.create ? 1 : 0
+
+  name = var.sns_topic_name
+
+  kms_master_key_id = var.sns_topic_kms_key_id
+
+  lambda_failure_feedback_role_arn    = var.enable_sns_topic_delivery_status_logs ? local.sns_feedback_role : null
+  lambda_success_feedback_role_arn    = var.enable_sns_topic_delivery_status_logs ? local.sns_feedback_role : null
+  lambda_success_feedback_sample_rate = var.enable_sns_topic_delivery_status_logs ? var.sns_topic_lambda_feedback_sample_rate : null
+
+  tags = merge(var.tags, var.sns_topic_tags)
+}
+
+
+resource "aws_sns_topic_subscription" "sns_notify_slack" {
+  count = var.create ? 1 : 0
+
+  topic_arn           = local.sns_topic_arn
+  protocol            = "lambda"
+  endpoint            = module.lambda.lambda_function_arn
+  filter_policy       = var.subscription_filter_policy
+  filter_policy_scope = var.subscription_filter_policy_scope
+}
+
+module "lambda" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "3.2.0"
+
+  create = var.create
+
+  function_name = var.lambda_function_name
+  description   = var.lambda_description
+
+  handler                        = "${local.lambda_handler}.lambda_handler"
+  source_path                    = var.lambda_source_path != null ? "${path.root}/${var.lambda_source_path}" : "${path.module}/functions/notify_slack.py"
+  recreate_missing_package       = var.recreate_missing_package
+  runtime                        = "python3.8"
+  timeout                        = 30
+  kms_key_arn                    = var.kms_key_arn
+  reserved_concurrent_executions = var.reserved_concurrent_executions
+  ephemeral_storage_size         = var.lambda_function_ephemeral_storage_size
+
+  # If publish is disabled, there will be "Error adding new Lambda Permission for notify_slack:
+  # InvalidParameterValueException: We currently do not support adding policies for $LATEST."
+  publish = true
+
+  environment_variables = {
+    SLACK_WEBHOOK_URL = var.slack_webhook_url
+    SLACK_CHANNEL     = var.slack_channel
+    SLACK_USERNAME    = var.slack_username
+    SLACK_EMOJI       = var.slack_emoji
+    LOG_EVENTS        = var.log_events ? "True" : "False"
+  }
+
+  create_role               = var.lambda_role == ""
+  lambda_role               = var.lambda_role
+  role_name                 = "${var.iam_role_name_prefix}-${var.lambda_function_name}"
+  role_permissions_boundary = var.iam_role_boundary_policy_arn
+  role_tags                 = var.iam_role_tags
+  role_path                 = var.iam_role_path
+  policy_path               = var.iam_policy_path
+
+  # Do not use Lambda's policy for cloudwatch logs, because we have to add a policy
+  # for KMS conditionally. This way attach_policy_json is always true independenty of
+  # the value of presense of KMS. Famous "computed values in count" bug...
+  attach_cloudwatch_logs_policy = false
+  attach_policy_json            = true
+  policy_json                   = try(data.aws_iam_policy_document.lambda[0].json, "")
+
+  use_existing_cloudwatch_log_group = true
+  attach_network_policy             = var.lambda_function_vpc_subnet_ids != null
+
+  dead_letter_target_arn    = var.lambda_dead_letter_target_arn
+  attach_dead_letter_policy = var.lambda_attach_dead_letter_policy
+
+  allowed_triggers = {
+    AllowExecutionFromSNS = {
+      principal  = "sns.amazonaws.com"
+      source_arn = local.sns_topic_arn
+    }
+  }
+
+  store_on_s3 = var.lambda_function_store_on_s3
+  s3_bucket   = var.lambda_function_s3_bucket
+
+  vpc_subnet_ids         = var.lambda_function_vpc_subnet_ids
+  vpc_security_group_ids = var.lambda_function_vpc_security_group_ids
+
+  tags = merge(var.tags, var.lambda_function_tags)
+
+  depends_on = [aws_cloudwatch_log_group.lambda]
+}

--- a/aws/aws-notify-slack/outputs.tf
+++ b/aws/aws-notify-slack/outputs.tf
@@ -1,0 +1,55 @@
+output "slack_topic_arn" {
+  description = "The ARN of the SNS topic from which messages will be sent to Slack"
+  value       = local.sns_topic_arn
+}
+
+# todo: Remove `this_slack_topic_arn` output during next major release 5.x
+output "this_slack_topic_arn" {
+  description = "The ARN of the SNS topic from which messages will be sent to Slack (backward compatibility for version 4.x)"
+  value       = local.sns_topic_arn
+}
+
+output "lambda_iam_role_arn" {
+  description = "The ARN of the IAM role used by Lambda function"
+  value       = module.lambda.lambda_role_arn
+}
+
+output "lambda_iam_role_name" {
+  description = "The name of the IAM role used by Lambda function"
+  value       = module.lambda.lambda_role_name
+}
+
+output "notify_slack_lambda_function_arn" {
+  description = "The ARN of the Lambda function"
+  value       = module.lambda.lambda_function_arn
+}
+
+output "notify_slack_lambda_function_name" {
+  description = "The name of the Lambda function"
+  value       = module.lambda.lambda_function_name
+}
+
+output "notify_slack_lambda_function_invoke_arn" {
+  description = "The ARN to be used for invoking Lambda function from API Gateway"
+  value       = module.lambda.lambda_function_invoke_arn
+}
+
+output "notify_slack_lambda_function_last_modified" {
+  description = "The date Lambda function was last modified"
+  value       = module.lambda.lambda_function_last_modified
+}
+
+output "notify_slack_lambda_function_version" {
+  description = "Latest published version of your Lambda function"
+  value       = module.lambda.lambda_function_version
+}
+
+output "lambda_cloudwatch_log_group_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the log group"
+  value       = try(aws_cloudwatch_log_group.lambda[0].arn, "")
+}
+
+output "sns_topic_feedback_role_arn" {
+  description = "The Amazon Resource Name (ARN) of the IAM role used for SNS delivery status logging"
+  value       = local.sns_feedback_role
+}

--- a/aws/aws-notify-slack/variables.tf
+++ b/aws/aws-notify-slack/variables.tf
@@ -1,0 +1,271 @@
+variable "putin_khuylo" {
+  description = "Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo!"
+  type        = bool
+  default     = true
+}
+
+variable "create" {
+  description = "Whether to create all resources"
+  type        = bool
+  default     = true
+}
+
+variable "create_sns_topic" {
+  description = "Whether to create new SNS topic"
+  type        = bool
+  default     = true
+}
+
+variable "lambda_role" {
+  description = "IAM role attached to the Lambda Function.  If this is set then a role will not be created for you."
+  type        = string
+  default     = ""
+}
+
+variable "lambda_function_name" {
+  description = "The name of the Lambda function to create"
+  type        = string
+  default     = "notify_slack"
+}
+
+variable "lambda_description" {
+  description = "The description of the Lambda function"
+  type        = string
+  default     = null
+}
+
+variable "lambda_source_path" {
+  description = "The source path of the custom Lambda function"
+  type        = string
+  default     = null
+}
+
+variable "lambda_dead_letter_target_arn" {
+  description = "The ARN of an SNS topic or SQS queue to notify when an invocation fails."
+  type        = string
+  default     = null
+}
+
+variable "lambda_attach_dead_letter_policy" {
+  description = "Controls whether SNS/SQS dead letter notification policy should be added to IAM role for Lambda Function"
+  type        = bool
+  default     = false
+}
+
+variable "sns_topic_name" {
+  description = "The name of the SNS topic to create"
+  type        = string
+}
+
+variable "sns_topic_kms_key_id" {
+  description = "ARN of the KMS key used for enabling SSE on the topic"
+  type        = string
+  default     = ""
+}
+
+variable "enable_sns_topic_delivery_status_logs" {
+  description = "Whether to enable SNS topic delivery status logs"
+  type        = bool
+  default     = false
+}
+
+variable "sns_topic_lambda_feedback_role_arn" {
+  description = "IAM role for SNS topic delivery status logs.  If this is set then a role will not be created for you."
+  type        = string
+  default     = ""
+}
+
+variable "sns_topic_feedback_role_name" {
+  description = "Name of the IAM role to use for SNS topic delivery status logging"
+  type        = string
+  default     = null
+}
+
+variable "sns_topic_feedback_role_description" {
+  description = "Description of IAM role to use for SNS topic delivery status logging"
+  type        = string
+  default     = null
+}
+
+variable "sns_topic_feedback_role_path" {
+  description = "Path of IAM role to use for SNS topic delivery status logging"
+  type        = string
+  default     = null
+}
+
+variable "sns_topic_feedback_role_force_detach_policies" {
+  description = "Specifies to force detaching any policies the IAM role has before destroying it."
+  type        = bool
+  default     = true
+}
+
+variable "sns_topic_feedback_role_permissions_boundary" {
+  description = "The ARN of the policy that is used to set the permissions boundary for the IAM role used by SNS topic delivery status logging"
+  type        = string
+  default     = null
+}
+
+variable "sns_topic_feedback_role_tags" {
+  description = "A map of tags to assign to IAM the SNS topic feedback role"
+  type        = map(string)
+  default     = {}
+}
+
+variable "sns_topic_lambda_feedback_sample_rate" {
+  description = "The percentage of successful deliveries to log"
+  type        = number
+  default     = 100
+}
+
+variable "slack_webhook_url" {
+  description = "The URL of Slack webhook"
+  type        = string
+}
+
+variable "slack_channel" {
+  description = "The name of the channel in Slack for notifications"
+  type        = string
+}
+
+variable "slack_username" {
+  description = "The username that will appear on Slack messages"
+  type        = string
+}
+
+variable "slack_emoji" {
+  description = "A custom emoji that will appear on Slack messages"
+  type        = string
+  default     = ":aws:"
+}
+
+variable "kms_key_arn" {
+  description = "ARN of the KMS key used for decrypting slack webhook url"
+  type        = string
+  default     = ""
+}
+
+variable "recreate_missing_package" {
+  description = "Whether to recreate missing Lambda package if it is missing locally or not"
+  type        = bool
+  default     = true
+}
+
+variable "log_events" {
+  description = "Boolean flag to enabled/disable logging of incoming events"
+  type        = bool
+  default     = false
+}
+
+variable "reserved_concurrent_executions" {
+  description = "The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations"
+  type        = number
+  default     = -1
+}
+
+variable "cloudwatch_log_group_retention_in_days" {
+  description = "Specifies the number of days you want to retain log events in log group for Lambda."
+  type        = number
+  default     = 0
+}
+
+variable "cloudwatch_log_group_kms_key_id" {
+  description = "The ARN of the KMS Key to use when encrypting log data for Lambda"
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "iam_role_tags" {
+  description = "Additional tags for the IAM role"
+  type        = map(string)
+  default     = {}
+}
+
+variable "iam_role_boundary_policy_arn" {
+  description = "The ARN of the policy that is used to set the permissions boundary for the role"
+  type        = string
+  default     = null
+}
+
+variable "iam_role_name_prefix" {
+  description = "A unique role name beginning with the specified prefix"
+  type        = string
+  default     = "lambda"
+}
+
+variable "iam_role_path" {
+  description = "Path of IAM role to use for Lambda Function"
+  type        = string
+  default     = null
+}
+
+variable "iam_policy_path" {
+  description = "Path of policies to that should be added to IAM role for Lambda Function"
+  type        = string
+  default     = null
+}
+
+variable "lambda_function_tags" {
+  description = "Additional tags for the Lambda function"
+  type        = map(string)
+  default     = {}
+}
+
+variable "lambda_function_vpc_subnet_ids" {
+  description = "List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets."
+  type        = list(string)
+  default     = null
+}
+
+variable "lambda_function_vpc_security_group_ids" {
+  description = "List of security group ids when Lambda Function should run in the VPC."
+  type        = list(string)
+  default     = null
+}
+
+variable "lambda_function_store_on_s3" {
+  description = "Whether to store produced artifacts on S3 or locally."
+  type        = bool
+  default     = false
+}
+
+variable "lambda_function_s3_bucket" {
+  description = "S3 bucket to store artifacts"
+  type        = string
+  default     = null
+}
+
+variable "lambda_function_ephemeral_storage_size" {
+  description = "Amount of ephemeral storage (/tmp) in MB your Lambda Function can use at runtime. Valid value between 512 MB to 10,240 MB (10 GB)."
+  type        = number
+  default     = 512
+}
+
+variable "sns_topic_tags" {
+  description = "Additional tags for the SNS topic"
+  type        = map(string)
+  default     = {}
+}
+
+variable "cloudwatch_log_group_tags" {
+  description = "Additional tags for the Cloudwatch log group"
+  type        = map(string)
+  default     = {}
+}
+
+variable "subscription_filter_policy" {
+  description = "(Optional) A valid filter policy that will be used in the subscription to filter messages seen by the target resource."
+  type        = string
+  default     = null
+}
+
+variable "subscription_filter_policy_scope" {
+  description = "(Optional) A valid filter policy scope MessageAttributes|MessageBody"
+  type        = string
+  default     = null
+}

--- a/aws/aws-notify-slack/versions.tf
+++ b/aws/aws-notify-slack/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.8"
+    }
+  }
+}


### PR DESCRIPTION
### Jira link

HOTT-4081

### What?

I have added/removed/altered:

- Added terraform module to send aws cloudwatch alarm alerts to slack


### Why?

I am doing this because:

- To send slack alerts on triggered cloudwatch alarms

