### PR TITLE
HOTT-4358: Enable Origin Access Identities on s3 origins

### DIFF
--- a/aws/cloudfront/README.md
+++ b/aws/cloudfront/README.md
@@ -21,8 +21,12 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_cloudfront_distribution.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) | resource |
+| [aws_cloudfront_origin_access_identity.s3_origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_identity) | resource |
 | [aws_route53_record.alias_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.cname_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_s3_bucket_policy.s3_origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_iam_policy_document.s3_origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 
 ## Inputs
 

--- a/aws/cloudfront/main.tf
+++ b/aws/cloudfront/main.tf
@@ -122,18 +122,6 @@ resource "aws_cloudfront_distribution" "this" {
       cached_methods  = lookup(i.value, "cached_methods", ["GET", "HEAD"])
       compress        = lookup(i.value, "compress", null)
 
-      forwarded_values {
-        query_string = lookup(i.value, "query_string", null)
-
-        cookies {
-          forward           = lookup(i.value, "cookies_forward", "none")
-          whitelisted_names = lookup(i.value, "cookies_whitelisted_names", [])
-        }
-
-        headers                 = lookup(i.value, "headers", [])
-        query_string_cache_keys = lookup(i.value, "query_string_cache_keys", [])
-      }
-
       field_level_encryption_id = lookup(i.value, "field_level_encryption_id", null)
       smooth_streaming          = lookup(i.value, "smooth_streaming", null)
       trusted_signers           = lookup(i.value, "trusted_signers", null)

--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -13,7 +13,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4 |
 
 ## Modules
 

--- a/aws/ssm/example/README.md
+++ b/aws/ssm/example/README.md
@@ -29,7 +29,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules
 

--- a/aws/waf/README.md
+++ b/aws/waf/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.11.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4358

### What?

I have added/removed/altered:

- [x] Added resources to give the CDN permissions to access s3 buckets

### Why?

I am doing this because:

- You can't access a bucket as an OAI without permissions
