### PR TITLE
BAU: Add Support for CloudFront Functions

### DIFF
--- a/aws/cloudfront/README.md
+++ b/aws/cloudfront/README.md
@@ -21,12 +21,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_cloudfront_distribution.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) | resource |
-| [aws_cloudfront_origin_access_identity.s3_origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_identity) | resource |
 | [aws_route53_record.alias_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.cname_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_s3_bucket_policy.s3_origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
-| [aws_iam_policy_document.s3_origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 
 ## Inputs
 

--- a/aws/cloudfront/main.tf
+++ b/aws/cloudfront/main.tf
@@ -96,6 +96,16 @@ resource "aws_cloudfront_distribution" "this" {
       cache_policy_id          = i.value["cache_policy_id"]
       origin_request_policy_id = i.value["origin_request_policy_id"]
 
+      dynamic "function_association" {
+        for_each = lookup(i.value, "function_association", [])
+        iterator = "f"
+
+        content {
+          event_type   = f.key
+          function_arn = f.value.function_arn
+        }
+      }
+
       dynamic "lambda_function_association" {
         for_each = lookup(i.value, "lambda_function_association", [])
         iterator = l
@@ -132,6 +142,27 @@ resource "aws_cloudfront_distribution" "this" {
 
       cache_policy_id          = i.value["cache_policy_id"]
       origin_request_policy_id = i.value["origin_request_policy_id"]
+
+      dynamic "function_association" {
+        for_each = lookup(i.value, "function_association", [])
+        iterator = "f"
+
+        content {
+          event_type   = f.key
+          function_arn = f.value.function_arn
+        }
+      }
+
+      dynamic "lambda_function_association" {
+        for_each = lookup(i.value, "lambda_function_association", [])
+        iterator = l
+
+        content {
+          event_type   = l.key
+          lambda_arn   = l.value.lambda_arn
+          include_body = lookup(l.value, "include_body", null)
+        }
+      }
     }
   }
 

--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -13,7 +13,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
 
 ## Modules
 

--- a/aws/ssm/example/README.md
+++ b/aws/ssm/example/README.md
@@ -29,7 +29,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules
 

--- a/aws/waf/README.md
+++ b/aws/waf/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.11.0 |
 
 ## Modules
 

--- a/trade-tariff/common/README.md
+++ b/trade-tariff/common/README.md
@@ -87,7 +87,6 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_docker_repositories"></a> [docker\_repositories](#input\_docker\_repositories) | List of repositories to create | `list(string)` | <pre>[<br>  "tariff-backend",<br>  "tariff-frontend",<br>  "tariff-dutycalculator",<br>  "tariff-admin",<br>  "tariff-search-query-parser",<br>  "signon"<br>]</pre> | no |
 | <a name="input_environments"></a> [environments](#input\_environments) | list of environment name keys to use in environment interpolations | `list(any)` | <pre>[<br>  "development",<br>  "staging",<br>  "production"<br>]</pre> | no |
-| <a name="input_notification_email"></a> [notification\_email](#input\_notification\_email) | Email address from where to send worker reports | `string` | `"trade-tariff-support@enginegroup.com"` | no |
 | <a name="input_project-key"></a> [project-key](#input\_project-key) | The project key to use in prefixing resources | `string` | `"trade-tariff"` | no |
 
 ## Outputs

--- a/trade-tariff/common/s3.tf
+++ b/trade-tariff/common/s3.tf
@@ -110,7 +110,7 @@ resource "aws_s3_bucket_public_access_block" "database-backups" {
 
 resource "aws_s3_bucket_public_access_block" "persistence" {
   count  = length(aws_s3_bucket.persistence)
-  bucket = aws_s3_bucket.persistence.*.id[count.index]
+  bucket = aws_s3_bucket.persistence[*].id[count.index]
 
   restrict_public_buckets = true
   block_public_acls       = true
@@ -120,7 +120,7 @@ resource "aws_s3_bucket_public_access_block" "persistence" {
 
 resource "aws_s3_bucket_public_access_block" "opensearch-packages" {
   count  = length(aws_s3_bucket.opensearch_packages)
-  bucket = aws_s3_bucket.opensearch_packages.*.id[count.index]
+  bucket = aws_s3_bucket.opensearch_packages[*].id[count.index]
 
   restrict_public_buckets = true
   block_public_acls       = true
@@ -130,7 +130,7 @@ resource "aws_s3_bucket_public_access_block" "opensearch-packages" {
 
 resource "aws_s3_bucket_public_access_block" "search-configuration" {
   count  = length(aws_s3_bucket.search_configuration)
-  bucket = aws_s3_bucket.search_configuration.*.id[count.index]
+  bucket = aws_s3_bucket.search_configuration[*].id[count.index]
 
   restrict_public_buckets = true
   block_public_acls       = true

--- a/trade-tariff/common/variables.tf
+++ b/trade-tariff/common/variables.tf
@@ -11,12 +11,6 @@ variable "environments" {
   default     = ["development", "staging", "production"]
 }
 
-variable "notification_email" {
-  type        = string
-  description = "Email address from where to send worker reports"
-  #  default = "no-reply@trade-tariff.service.gov.uk"
-  default = "trade-tariff-support@enginegroup.com"
-}
 
 
 variable "docker_repositories" {


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Added support for CloudFront function associations in the CloudFront module, both in the default and ordered cache behaviour blocks.

### Why?

I am doing this because:

- We need to be able to associate a function to CloudFront distributions.
