### PR TITLE
HOTT-4670 Disable Size limit on body for now

### DIFF
--- a/aws/waf/variables.tf
+++ b/aws/waf/variables.tf
@@ -21,7 +21,7 @@ variable "managed_rules" {
     AWSManagedRulesCommonRuleSet = {
       priority        = 10
       override_action = "none"
-      excluded_rules  = ["NoUserAgent_HEADER"]
+      excluded_rules  = ["NoUserAgent_HEADER", "SizeRestrictions_BODY"]
     },
     AWSManagedRulesAmazonIpReputationList = {
       priority        = 20


### PR DESCRIPTION
### Jira link

HOTT-4670

### What?

I have added/removed/altered:

- [x] Disable WAF Size Restrictions on Body

### Why?

I am doing this because:

- It blocks posting news stories

### Have you? (optional)

- [ ] Reviewed infrastructure changes with stakeholders
- [x] Considered downstream users of the infrastructure

### Deployment risks (optional)

- Changes all CDN configurations
