### PR TITLE
HOTT-4852: Make init containers require exit code of 0

### DIFF
--- a/aws/ecs-service/locals.tf
+++ b/aws/ecs-service/locals.tf
@@ -31,7 +31,7 @@ locals {
     {
       name        = var.service_name
       image       = "${var.docker_image}:${var.docker_tag}"
-      essential   = true
+      essential   = false
       environment = var.service_environment_config
       secrets     = var.service_secrets_config
       entryPoint  = var.container_entrypoint
@@ -53,7 +53,7 @@ locals {
 
       dependsOn = [{
         containerName = "${var.service_name}-init"
-        condition     = "COMPLETE"
+        condition     = "SUCCESS"
       }]
     }
   ]


### PR DESCRIPTION
### Jira link

[HOTT-4852](https://transformuk.atlassian.net/browse/HOTT-4852)

### What?

I have added/removed/altered:

- Changed init containers to be non-essential.
- Updated main service container definition to require an exit code of `0` on the init container before starting.

### Why?

I am doing this because:

- Our use of this init container is to run database migrations. If the migration is not successful (i.e. the migration fails) it should fail the deployment.