### PR TITLE
BAU: Service container should be essential

### DIFF
--- a/aws/ecs-service/locals.tf
+++ b/aws/ecs-service/locals.tf
@@ -31,7 +31,7 @@ locals {
     {
       name        = var.service_name
       image       = "${var.docker_image}:${var.docker_tag}"
-      essential   = false
+      essential   = true
       environment = var.service_environment_config
       secrets     = var.service_secrets_config
       entryPoint  = var.container_entrypoint


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Fixed service container being non-essential.

### Why?

I am doing this because:

- In the last PR I mistakenly set the service container's `essential` to `false` when I had meant to do this for the init container - this was already `false`, so I just introduced a bug. 😢 
