### PR TITLE
BAU: Output Zone ID from Cognito User Pool Domain

### DIFF
--- a/aws/cognito/README.md
+++ b/aws/cognito/README.md
@@ -128,6 +128,7 @@ No modules.
 |------|-------------|
 | <a name="output_client_id"></a> [client\_id](#output\_client\_id) | n/a |
 | <a name="output_cloudfront_distribution_arn"></a> [cloudfront\_distribution\_arn](#output\_cloudfront\_distribution\_arn) | n/a |
+| <a name="output_cloudfront_distribution_zone_id"></a> [cloudfront\_distribution\_zone\_id](#output\_cloudfront\_distribution\_zone\_id) | n/a |
 | <a name="output_domain"></a> [domain](#output\_domain) | n/a |
 | <a name="output_user_pool_arn"></a> [user\_pool\_arn](#output\_user\_pool\_arn) | n/a |
 | <a name="output_user_pool_id"></a> [user\_pool\_id](#output\_user\_pool\_id) | n/a |

--- a/aws/cognito/outputs.tf
+++ b/aws/cognito/outputs.tf
@@ -17,3 +17,7 @@ output "domain" {
 output "cloudfront_distribution_arn" {
   value = aws_cognito_user_pool_domain.this[0].cloudfront_distribution_arn
 }
+
+output "cloudfront_distribution_zone_id" {
+  value = aws_cognito_user_pool_domain.this[0].cloudfront_distribution_zone_id
+}


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Added output for the Cognito domain's CloudFront Distribution Zone ID.

### Why?

I am doing this because:

- It's needed to make the A record work.