### PR TITLE
BAU: Disable squash commits

### DIFF
--- a/aws/cognito/README.md
+++ b/aws/cognito/README.md
@@ -45,8 +45,8 @@ resource "aws_route53_record" "cognito_custom_domain" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.43.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
 
 ## Modules
 

--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -13,7 +13,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4 |
 
 ## Modules
 

--- a/aws/waf/README.md
+++ b/aws/waf/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.11.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/github/repos/README.md
+++ b/github/repos/README.md
@@ -36,7 +36,7 @@ No modules.
 | <a name="input_admin_teams"></a> [admin\_teams](#input\_admin\_teams) | n/a | `list(any)` | `[]` | no |
 | <a name="input_allow_push_to_main"></a> [allow\_push\_to\_main](#input\_allow\_push\_to\_main) | n/a | `string` | `"true"` | no |
 | <a name="input_allow_rebase_merge"></a> [allow\_rebase\_merge](#input\_allow\_rebase\_merge) | n/a | `bool` | `false` | no |
-| <a name="input_allow_squash_merge"></a> [allow\_squash\_merge](#input\_allow\_squash\_merge) | n/a | `bool` | `true` | no |
+| <a name="input_allow_squash_merge"></a> [allow\_squash\_merge](#input\_allow\_squash\_merge) | n/a | `bool` | `false` | no |
 | <a name="input_archived"></a> [archived](#input\_archived) | n/a | `bool` | `false` | no |
 | <a name="input_default_branch_name"></a> [default\_branch\_name](#input\_default\_branch\_name) | n/a | `string` | `"main"` | no |
 | <a name="input_delete_branch_on_merge"></a> [delete\_branch\_on\_merge](#input\_delete\_branch\_on\_merge) | n/a | `bool` | `true` | no |

--- a/github/repos/variables.tf
+++ b/github/repos/variables.tf
@@ -101,7 +101,7 @@ variable "allow_rebase_merge" {
 
 variable "allow_squash_merge" {
   type    = bool
-  default = true
+  default = false
 }
 
 variable "has_downloads" {


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Removed squash commit default setting

### Why?

I am doing this because:

- These don't create merge commits which are needed to highlight merged pull requests for our release process.
- I misunderstood and approved this change, here https://github.com/trade-tariff/trade-tariff-platform-terraform-modules/pull/9/files
- I'm leaving this option since its technically possible in some repos for this not to affect releases
