### PR TITLE
BAU: Fixes broken registration logic

### DIFF
--- a/aws/cognito/main.tf
+++ b/aws/cognito/main.tf
@@ -27,7 +27,7 @@ resource "aws_cognito_user_pool" "this" {
   }
 
   admin_create_user_config {
-    allow_admin_create_user_only = var.allow_user_registration ? false : true
+    allow_admin_create_user_only = var.allow_user_registration
     dynamic "invite_message_template" {
       for_each = var.invite_message_template != null ? [var.invite_message_template] : []
       content {

--- a/aws/cognito/variables.tf
+++ b/aws/cognito/variables.tf
@@ -58,7 +58,7 @@ variable "recovery_mechanisms" {
 variable "allow_user_registration" {
   description = "Whether users can sign themselves up. If false, only the administrator can create user profiles."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "invite_message_template" {


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] I've changed the default value of enabling user registration in the cognito module to true
- [x] Simplified the conditional handling for enabling user registration which had inversed logic

### Why?

I am doing this because:

- The inverted logic is confusing to the clients of the cognito module
- The default value of true is what's actually live in all environments today (we can manually change these separately)
