### PR TITLE
HMRC-635 Reduce WAF sample window

### DIFF
--- a/aws/waf/main.tf
+++ b/aws/waf/main.tf
@@ -145,9 +145,9 @@ resource "aws_wafv2_web_acl" "this" {
 
       statement {
         rate_based_statement {
-          limit              = rule.value.rpm_limit * 5
-          aggregate_key_type = "IP"
-
+          limit                 = rule.value.rpm_limit
+          evaluation_window_sec = 60
+          aggregate_key_type    = "IP"
         }
       }
 


### PR DESCRIPTION
### Jira link

HMRC-635

### What?

Currently we use a 5 minute window for WAF rate sampling.  This PR reduces that to a minute to improve reaction speeds