### PR TITLE
Configure invitation message

### DIFF
--- a/aws/cognito/README.md
+++ b/aws/cognito/README.md
@@ -32,7 +32,7 @@ resource "aws_route53_record" "cognito_custom_domain" {
 
 ---
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -138,4 +138,4 @@ No modules.
 | <a name="output_user_pool_arn"></a> [user\_pool\_arn](#output\_user\_pool\_arn) | n/a |
 | <a name="output_user_pool_id"></a> [user\_pool\_id](#output\_user\_pool\_id) | n/a |
 | <a name="output_user_pool_public_keys_url"></a> [user\_pool\_public\_keys\_url](#output\_user\_pool\_public\_keys\_url) | n/a |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/aws/cognito/main.tf
+++ b/aws/cognito/main.tf
@@ -164,6 +164,9 @@ resource "aws_cognito_user_pool" "this" {
 
   lifecycle {
     replace_triggered_by = [null_resource.schema_checksum]
+    ignore_changes = [
+      admin_create_user_config[0].invite_message_template
+    ]
   }
 
   tags = var.tags


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- Added a `lifecycle` block to prevent Terraform from overwriting the `invite_message_template` in the `aws_cognito_user_pool` resource.

### Why?

I am doing this because:

- This change ensures that custom invitation messages set manually are not overwritten by Terraform during future runs.


### Have you? (optional)

- [ ] Reviewed infrastructure changes with stakeholders
- [ ] Considered downstream users of the infrastructure
- [ ] Thought of ways to reduce down time

### Deployment risks (optional)

- This change could bring down our developer flows and cause disruption
- The core application uses these resources
