### PR TITLE
Revert "Merge pull request #68 from trade-tariff/hmrc-936-availability-zone-rebalancing"

### DIFF
--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.93.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5 |
 
 ## Modules
 
@@ -63,7 +63,6 @@ No modules.
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | A maximum capacity for autoscaling. | `number` | n/a | yes |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory limits for container. | `number` | `512` | no |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | A minimum capacity for autoscaling. Defaults to 1. | `number` | `1` | no |
-| <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | Whether to enable availability zone rebalancing (requires multiple subnets to be passed to the service, and a service count above 1). Defaults to `true`. | `bool` | `true` | no |
 | <a name="input_private_dns_namespace"></a> [private\_dns\_namespace](#input\_private\_dns\_namespace) | Private DNS namespace name. If provided, enables service discovery. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region. | `string` | n/a | yes |
 | <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of security group IDs to asssociate with the service. | `list(string)` | n/a | yes |

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -35,14 +35,6 @@ resource "aws_ecs_service" "this" {
     rollback = var.enable_rollback
   }
 
-  dynamic "ordered_placement_strategy" {
-    for_each = var.multi_az ? [true] : []
-    content {
-      type  = "spread"
-      field = "attribute:ecs.availability-zone"
-    }
-  }
-
   deployment_maximum_percent         = var.deployment_maximum_percent
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
   wait_for_steady_state              = var.wait_for_steady_state

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -206,9 +206,3 @@ variable "init_container_command" {
   type        = list(string)
   default     = null
 }
-
-variable "multi_az" {
-  description = "Whether to enable availability zone rebalancing (requires multiple subnets to be passed to the service, and a service count above 1). Defaults to `true`."
-  type        = bool
-  default     = true
-}


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-798

### What?

I have added/removed/altered:

- [x] Reverts zone rebalancing changes to ecs-service module

### Why?

I am doing this because:

- I want to make adjustments to this module to support arbitrary scheduled tasks and I discovered this change was broken when updating this module recently
