### PR TITLE
HMRC-964: Require up-to-date branches

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.98.0
+    rev: v1.99.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -27,3 +27,13 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
+
+  - repo: https://github.com/trufflesecurity/trufflehog
+    rev: v3.88.25
+    hooks:
+      - id: trufflehog
+
+  - repo: https://github.com/rhysd/actionlint.git
+    rev: v1.7.7
+    hooks:
+      - id: actionlint-docker

--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.95.0 |
 
 ## Modules
 
@@ -44,7 +44,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_autoscaling_metrics"></a> [autoscaling\_metrics](#input\_autoscaling\_metrics) | A map of autoscaling metrics. | <pre>map(object({<br>    metric_type  = string<br>    target_value = number<br>  }))</pre> | <pre>{<br>  "cpu": {<br>    "metric_type": "ECSServiceAverageCPUUtilization",<br>    "target_value": 40<br>  },<br>  "memory": {<br>    "metric_type": "ECSServiceAverageMemoryUtilization",<br>    "target_value": 40<br>  }<br>}</pre> | no |
+| <a name="input_autoscaling_metrics"></a> [autoscaling\_metrics](#input\_autoscaling\_metrics) | A map of autoscaling metrics. | <pre>map(object({<br/>    metric_type  = string<br/>    target_value = number<br/>  }))</pre> | <pre>{<br/>  "cpu": {<br/>    "metric_type": "ECSServiceAverageCPUUtilization",<br/>    "target_value": 40<br/>  },<br/>  "memory": {<br/>    "metric_type": "ECSServiceAverageMemoryUtilization",<br/>    "target_value": 40<br/>  }<br/>}</pre> | no |
 | <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | CloudWatch log group to use with the service. | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the ECS Cluster to deploy the service into. | `string` | n/a | yes |
 | <a name="input_container_command"></a> [container\_command](#input\_container\_command) | String array representing the command to run in the container. First argument should be the shell to use, if required. Defaults to `null`, that is, no command override. | `list(string)` | `null` | no |

--- a/github/repos/README.md
+++ b/github/repos/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | >= 6.0 |
+| <a name="provider_github"></a> [github](#provider\_github) | 6.6.0 |
 
 ## Modules
 
@@ -22,6 +22,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [github_branch_protection.global_main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection) | resource |
 | [github_branch_protection.repo_protect_main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection) | resource |
 | [github_repository.repo](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 | [github_team_repository.repo_team_admin](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |

--- a/github/repos/main.tf
+++ b/github/repos/main.tf
@@ -92,3 +92,11 @@ resource "github_branch_protection" "repo_protect_main" {
     require_code_owner_reviews      = var.require_code_owner_reviews
   }
 }
+
+resource "github_branch_protection" "global_main" {
+  repository_id = github_repository.repo.node_id
+  pattern       = var.default_branch_name
+
+  # NOTE: This will force the feature branch to be up-to-date with the main branch
+  required_status_checks { strict = true }
+}

--- a/github/teams/README.md
+++ b/github/teams/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | >= 6.0 |
+| <a name="provider_github"></a> [github](#provider\_github) | 6.6.0 |
 
 ## Modules
 

--- a/github/users/README.md
+++ b/github/users/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | >= 6.0 |
+| <a name="provider_github"></a> [github](#provider\_github) | 6.6.0 |
 
 ## Modules
 


### PR DESCRIPTION
### Jira link

[HMRC-964](https://transformuk.atlassian.net/browse/HMRC-964)

### What?

I have added/removed/altered:

- Adds simple branch protection globally
- Bumps pre-commit and adds some additional useful hooks

### Why?

I am doing this because:

- This will prevent us from deleting other people's changes in terraform repos and gives us some guarantees around implicit conflicts before merging in developer feature branches and represents an alternative to merge-queues that is signficantly simpler
