### PR TITLE
Replace container-based Terraform with hashicorp/setup-terraform@v2

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -7,10 +7,12 @@ on:
 jobs:
   fmt_validate_terraform:
     runs-on: ubuntu-latest
-    container:
-      image: hashicorp/terraform:1.11
+  
     steps:
     - uses: actions/checkout@v4.1.0
+    - uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: 1.11
     - name: terraform init
       run: |
         cd github


### PR DESCRIPTION
### Jira link

[HMRC-897](https://transformuk.atlassian.net/browse/HMRC-897)

### What?

I have added/removed/altered:

- [ ] Replaced `hashicorp/terraform:1.11` container with `hashicorp/setup-terraform@v2` 
- [ ] Removed baz

### Why?

I am doing this because:

- Since container: applies to the entire job, but actions/checkout runs on the host VM (ubuntu-latest), this might cause inconsistencies.


### Have you? (optional)

- [ ] Reviewed infrastructure changes with stakeholders
- [ ] Considered downstream users of the infrastructure
- [ ] Thought of ways to reduce down time

### Deployment risks (optional)

- This change could bring down our developer flows and cause disruption
- The core application uses these resources
