### PR TITLE
HMRC-798: Adds handling for job autoscaling

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   fmt_validate_terraform:
     runs-on: ubuntu-latest
-  
+
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: hashicorp/setup-terraform@v3

--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.92.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.95.0 |
 
 ## Modules
 

--- a/aws/ecs-service/data.tf
+++ b/aws/ecs-service/data.tf
@@ -1,0 +1,16 @@
+
+data "aws_caller_identity" "current" {}
+
+data "aws_ecs_cluster" "this" {
+  cluster_name = var.cluster_name
+}
+
+data "aws_cloudwatch_log_group" "this" {
+  name = var.cloudwatch_log_group_name
+}
+
+data "aws_service_discovery_dns_namespace" "this" {
+  count = var.private_dns_namespace != null ? 1 : 0
+  name  = var.private_dns_namespace
+  type  = "DNS_PRIVATE"
+}

--- a/aws/ecs-service/locals.tf
+++ b/aws/ecs-service/locals.tf
@@ -1,7 +1,6 @@
 locals {
   account_id  = data.aws_caller_identity.current.account_id
   cluster_arn = data.aws_ecs_cluster.this.arn
-
   tags = merge(
     {
       Terraform = "true"
@@ -107,20 +106,9 @@ locals {
       }
     }
   }]
-}
 
-data "aws_caller_identity" "current" {}
+  # NOTE: Jobs that are ran on a schedule should not use an autoscaling policy and should instead start/stop as per the run-task command.
+  has_autoscaler = var.container_definition_kind != "job" ? true : false
 
-data "aws_ecs_cluster" "this" {
-  cluster_name = var.cluster_name
-}
-
-data "aws_cloudwatch_log_group" "this" {
-  name = var.cloudwatch_log_group_name
-}
-
-data "aws_service_discovery_dns_namespace" "this" {
-  count = var.private_dns_namespace != null ? 1 : 0
-  name  = var.private_dns_namespace
-  type  = "DNS_PRIVATE"
+  autoscaling_metrics = local.has_autoscaler ? var.autoscaling_metrics : {}
 }

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -79,6 +79,7 @@ resource "aws_ecs_task_definition" "this" {
 }
 
 resource "aws_appautoscaling_target" "this" {
+  count              = local.has_autoscaler ? 1 : 0
   max_capacity       = var.max_capacity
   min_capacity       = var.min_capacity
   resource_id        = "service/${var.cluster_name}/${aws_ecs_service.this.name}"
@@ -87,12 +88,12 @@ resource "aws_appautoscaling_target" "this" {
 }
 
 resource "aws_appautoscaling_policy" "this" {
-  for_each           = var.autoscaling_metrics
+  for_each           = local.autoscaling_metrics
   name               = "${aws_ecs_service.this.name}-scaling-policy-${each.key}"
   policy_type        = "TargetTrackingScaling"
-  resource_id        = aws_appautoscaling_target.this.resource_id
-  scalable_dimension = aws_appautoscaling_target.this.scalable_dimension
-  service_namespace  = aws_appautoscaling_target.this.service_namespace
+  resource_id        = aws_appautoscaling_target.this[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.this[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.this[0].service_namespace
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {
@@ -101,7 +102,7 @@ resource "aws_appautoscaling_policy" "this" {
     target_value = each.value.target_value
   }
 
-  depends_on = [aws_appautoscaling_target.this]
+  depends_on = [aws_appautoscaling_target.this[0]]
 }
 
 resource "aws_service_discovery_service" "this" {


### PR DESCRIPTION
### Jira link

[HMRC-798](https://transformuk.atlassian.net/browse/HMRC-798)

### What?

I have added/removed/altered:

- [x] Added autoscaler handling for the `job` kind of service definition

### Why?

I am doing this because:

- Essentially, we do not want autoscaling policies/actions to kick in when we're running a job.
We've noticed that when running a long running job this will stop our
container mid-job which is undesirable/leaving development in a broken
state
