### PR TITLE
HMRC-1563: Increase ecs autoscaling

### DIFF
--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -114,11 +114,11 @@ variable "autoscaling_metrics" {
   default = {
     cpu = {
       metric_type  = "ECSServiceAverageCPUUtilization"
-      target_value = 40
+      target_value = 75
     },
     memory = {
       metric_type  = "ECSServiceAverageMemoryUtilization"
-      target_value = 40
+      target_value = 70
     }
   }
 }


### PR DESCRIPTION
### Jira link

[HMRC-1563](https://transformuk.atlassian.net/browse/HMRC-1563)

### What?

I have added/removed/altered:

Adjusted autoscaling target utilisation for ECS services:
- [x] CPU: 40% → 75%
- [x] Memory: 40% → 70%

### Why?

I am doing this because:

- 70–75% is a commonly recommended threshold for ECS/Fargate autoscaling, keeping tasks responsive while avoiding unnecessary scaling.
- With the recent reduction of CPU/Memory for Backend and Frontend services, the previous 40% target was too conservative.