### PR TITLE
Fix cloudwatch service count alert

### DIFF
--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -125,7 +125,7 @@ resource "aws_cloudwatch_metric_alarm" "service_count" {
   alarm_name        = "Task Count (${var.service_name})"
   alarm_description = "Task count alarm for ${var.service_name}"
 
-  namespace           = "AWS/ECS"
+  namespace           = "ECS/ContainerInsights"
   metric_name         = "RunningTaskCount"
   threshold           = 1
   evaluation_periods  = 5


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Changed `namespace` from `AWS/ECS` to `ECS/ContainerInsights`

### Why?

I am doing this because:

- The RunningTaskCount metric is available under ECS/ContainerInsights, not AWS/ECS.

### Have you? (optional)

- [ ] Reviewed infrastructure changes with stakeholders
- [ ] Considered downstream users of the infrastructure
- [ ] Thought of ways to reduce down time

### Deployment risks (optional)

- This change could bring down our developer flows and cause disruption
- The core application uses these resources
