### PR TITLE
HMRC-1766: Configure scaling policies

### DIFF
--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -23,6 +23,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_appautoscaling_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_policy) | resource |
+| [aws_appautoscaling_scheduled_action.scheduled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_scheduled_action) | resource |
 | [aws_appautoscaling_target.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
 | [aws_cloudwatch_metric_alarm.ecs_capacity_loss](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.ecs_high_cpu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
@@ -46,7 +47,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_autoscaling_metrics"></a> [autoscaling\_metrics](#input\_autoscaling\_metrics) | A map of autoscaling metrics. | <pre>map(object({<br/>    metric_type  = string<br/>    target_value = number<br/>  }))</pre> | <pre>{<br/>  "cpu": {<br/>    "metric_type": "ECSServiceAverageCPUUtilization",<br/>    "target_value": 75<br/>  },<br/>  "memory": {<br/>    "metric_type": "ECSServiceAverageMemoryUtilization",<br/>    "target_value": 70<br/>  }<br/>}</pre> | no |
+| <a name="input_autoscaling_metrics"></a> [autoscaling\_metrics](#input\_autoscaling\_metrics) | A map of autoscaling metrics. | <pre>map(object({<br/>    metric_type  = string<br/>    target_value = number<br/>  }))</pre> | <pre>{<br/>  "cpu": {<br/>    "metric_type": "ECSServiceAverageCPUUtilization",<br/>    "target_value": 55<br/>  },<br/>  "memory": {<br/>    "metric_type": "ECSServiceAverageMemoryUtilization",<br/>    "target_value": 70<br/>  }<br/>}</pre> | no |
 | <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | CloudWatch log group to use with the service. | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the ECS Cluster to deploy the service into. | `string` | n/a | yes |
 | <a name="input_container_command"></a> [container\_command](#input\_container\_command) | String array representing the command to run in the container. First argument should be the shell to use, if required. Defaults to `null`, that is, no command override. | `list(string)` | `null` | no |
@@ -69,6 +70,10 @@ No modules.
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | A minimum capacity for autoscaling. Defaults to 1. | `number` | `1` | no |
 | <a name="input_private_dns_namespace"></a> [private\_dns\_namespace](#input\_private\_dns\_namespace) | Private DNS namespace name. If provided, enables service discovery. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region. | `string` | n/a | yes |
+| <a name="input_scale_in_cooldown"></a> [scale\_in\_cooldown](#input\_scale\_in\_cooldown) | Scale-in cooldown (seconds) applied to all target tracking policies. | `number` | `300` | no |
+| <a name="input_scale_out_cooldown"></a> [scale\_out\_cooldown](#input\_scale\_out\_cooldown) | Scale-out cooldown (seconds) applied to all target tracking policies. | `number` | `60` | no |
+| <a name="input_scheduled_actions_enabled"></a> [scheduled\_actions\_enabled](#input\_scheduled\_actions\_enabled) | Enable scheduled scaling actions. | `bool` | `false` | no |
+| <a name="input_scheduled_scaling_actions"></a> [scheduled\_scaling\_actions](#input\_scheduled\_scaling\_actions) | Map of scheduled scaling actions keyed by a unique name. Each value must include:<br/>- schedule     : AWS cron expression in UTC, e.g. 'cron(0 7 ? * MON-FRI *)'<br/>- min\_capacity : minimum desired tasks at schedule time<br/>- max\_capacity : maximum desired tasks at schedule time | <pre>map(object({<br/>    schedule     = string<br/>    min_capacity = number<br/>    max_capacity = number<br/>  }))</pre> | `{}` | no |
 | <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of security group IDs to asssociate with the service. | `list(string)` | n/a | yes |
 | <a name="input_service_count"></a> [service\_count](#input\_service\_count) | Number of replicas of the service to create. Defaults to 1. | `number` | `1` | no |
 | <a name="input_service_environment_config"></a> [service\_environment\_config](#input\_service\_environment\_config) | Service specific environment config | `list(map(string))` | `[]` | no |

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -114,13 +114,46 @@ variable "autoscaling_metrics" {
   default = {
     cpu = {
       metric_type  = "ECSServiceAverageCPUUtilization"
-      target_value = 75
+      target_value = 55
     },
     memory = {
       metric_type  = "ECSServiceAverageMemoryUtilization"
       target_value = 70
     }
   }
+}
+
+variable "scale_in_cooldown" {
+  description = "Scale-in cooldown (seconds) applied to all target tracking policies."
+  type        = number
+  default     = 300
+}
+
+variable "scale_out_cooldown" {
+  description = "Scale-out cooldown (seconds) applied to all target tracking policies."
+  type        = number
+  default     = 60
+}
+
+variable "scheduled_actions_enabled" {
+  description = "Enable scheduled scaling actions."
+  type        = bool
+  default     = false
+}
+
+variable "scheduled_scaling_actions" {
+  description = <<EOT
+Map of scheduled scaling actions keyed by a unique name. Each value must include:
+- schedule     : AWS cron expression in UTC, e.g. 'cron(0 7 ? * MON-FRI *)'
+- min_capacity : minimum desired tasks at schedule time
+- max_capacity : maximum desired tasks at schedule time
+EOT
+  type = map(object({
+    schedule     = string
+    min_capacity = number
+    max_capacity = number
+  }))
+  default = {}
 }
 
 variable "target_group_arn" {

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -124,19 +124,19 @@ variable "autoscaling_metrics" {
 }
 
 variable "scale_in_cooldown" {
-  description = "Scale-in cooldown (seconds) applied to all target tracking policies."
+  description = "Prevents aggressive scale-in by enforcing a waiting period after tasks are removed."
   type        = number
   default     = 300
 }
 
 variable "scale_out_cooldown" {
-  description = "Scale-out cooldown (seconds) applied to all target tracking policies."
+  description = "Minimum time to wait after a scale-out before allowing another scale-out, giving new tasks time to start contributing capacity."
   type        = number
   default     = 60
 }
 
 variable "scheduled_actions_enabled" {
-  description = "Enable scheduled scaling actions."
+  description = "Enables scheduled scaling to proactively increase or reduce capacity during predictable traffic patterns."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
### Jira link

[HMRC-1766](https://transformuk.atlassian.net/browse/HMRC-1766)

### What?

I have added/removed/altered:

- [x] Added scheduled scaling actions (configurable via parent module)
- [x] Updated target tracking policy:
        - Changed CPU target value from 75 to 55
        - Added configurable scale-in and scale-out cooldowns
        
### Why?

I am doing this because:

- The existing auto scaling behaviour is overly reactive, with a high CPU target (75%) leading to delayed scaling and potential performance degradation under load. 
- Reducing the target to 55% improves responsiveness, while scheduled scaling allows us to handle predictable traffic patterns proactively. 
- Configurable cooldowns are introduced to stabilise scaling behaviour and avoid unnecessary churn.
`scale_out_cooldown`- 60s (or 90s or 180s, depending on healthchek time) prevents stacking scale-outs before the first batch is healthy 
`scale_in_cooldown`  - 300s prevents a thrashing pattern visible in our connection data

### Have you? (optional)

- [ ] Reviewed infrastructure changes with stakeholders
- [ ] Considered downstream users of the infrastructure
- [ ] Thought of ways to reduce down time

### Deployment risks (optional)

- This change could bring down our developer flows and cause disruption
- The core application uses these resources
