### PR TITLE
HMRC-1842: Add critical ECS alerts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.102.0
+    rev: v1.105.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -21,11 +21,11 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.90.11
+    rev: v3.95.2
     hooks:
       - id: trufflehog
 
   - repo: https://github.com/rhysd/actionlint.git
-    rev: v1.7.8
+    rev: v1.7.12
     hooks:
       - id: actionlint-docker

--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5 |
 
 ## Modules
 
@@ -24,6 +24,8 @@ No modules.
 |------|------|
 | [aws_appautoscaling_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_policy) | resource |
 | [aws_appautoscaling_target.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
+| [aws_cloudwatch_metric_alarm.ecs_high_cpu_critical](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.ecs_task_flapping](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.service_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_ecs_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_task_definition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -167,7 +167,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_capacity_loss" {
   tags = local.tags
 
   metric_query {
-    id = "running"
+    id          = "running"
     return_data = false
 
     metric {
@@ -184,7 +184,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_capacity_loss" {
   }
 
   metric_query {
-    id = "desired"
+    id          = "desired"
     return_data = false
 
     metric {

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -145,3 +145,54 @@ resource "aws_cloudwatch_metric_alarm" "service_count" {
     ServiceName = var.service_name
   }
 }
+
+resource "aws_cloudwatch_metric_alarm" "ecs_task_flapping" {
+  count = var.enable_service_count_alarm && local.service_exists ? 1 : 0
+
+  alarm_name        = "ecs-task-flapping-${var.service_name}"
+  alarm_description = "ECS tasks restarting too frequently for ${var.service_name}"
+
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 3
+  evaluation_periods  = 5
+  datapoints_to_alarm = 1
+  treat_missing_data  = "notBreaching"
+
+  metric_name = "TaskStopped"
+  namespace   = "ECS/ContainerInsights"
+  period      = 60
+  statistic   = "Sum"
+
+  dimensions = {
+    ClusterName = data.aws_ecs_cluster.this.cluster_name
+    ServiceName = var.service_name
+  }
+
+  alarm_actions = var.sns_topic_arns
+  ok_actions    = var.sns_topic_arns
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_high_cpu_critical" {
+  count = var.enable_service_count_alarm && local.service_exists ? 1 : 0
+
+  alarm_name        = "ecs-high-cpu-${var.service_name}"
+  alarm_description = "ECS CPU > 75% for ${var.service_name} — potential scaling failure"
+
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 75
+  evaluation_periods  = 5
+  period              = 60
+  statistic           = "Average"
+  treat_missing_data  = "notBreaching"
+
+  namespace   = "ECS/ContainerInsights"
+  metric_name = "CpuUtilized"
+
+  dimensions = {
+    ClusterName = data.aws_ecs_cluster.this.cluster_name
+    ServiceName = var.service_name
+  }
+
+  alarm_actions = var.sns_topic_arns
+  ok_actions    = var.sns_topic_arns
+}

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -123,7 +123,7 @@ resource "aws_service_discovery_service" "this" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "service_count" {
-  count = var.enable_service_count_alarm && local.service_exists ? 1 : 0
+  count = var.enable_alarms && local.service_exists ? 1 : 0
 
   alarm_name        = "Task Count (${var.service_name})"
   alarm_description = "Task count alarm for ${var.service_name}"
@@ -144,55 +144,94 @@ resource "aws_cloudwatch_metric_alarm" "service_count" {
     ClusterName = data.aws_ecs_cluster.this.cluster_name
     ServiceName = var.service_name
   }
+
+  tags = local.tags
 }
 
-resource "aws_cloudwatch_metric_alarm" "ecs_task_flapping" {
-  count = var.enable_service_count_alarm && local.service_exists ? 1 : 0
+resource "aws_cloudwatch_metric_alarm" "ecs_capacity_loss" {
+  count = var.enable_alarms && local.service_exists ? 1 : 0
 
-  alarm_name        = "ecs-task-flapping-${var.service_name}"
-  alarm_description = "ECS tasks restarting too frequently for ${var.service_name}"
+  alarm_name        = "ecs-capacity-loss-${var.service_name}"
+  alarm_description = "ECS running task count below desired for ${var.service_name}"
 
-  comparison_operator = "GreaterThanThreshold"
-  threshold           = 3
+  comparison_operator = "LessThanThreshold"
+  threshold           = 0
   evaluation_periods  = 5
-  datapoints_to_alarm = 1
-  treat_missing_data  = "notBreaching"
+  datapoints_to_alarm = 3
 
-  metric_name = "TaskStopped"
-  namespace   = "ECS/ContainerInsights"
-  period      = 60
-  statistic   = "Sum"
-
-  dimensions = {
-    ClusterName = data.aws_ecs_cluster.this.cluster_name
-    ServiceName = var.service_name
-  }
+  treat_missing_data = "Breaching"
 
   alarm_actions = var.sns_topic_arns
   ok_actions    = var.sns_topic_arns
+
+  tags = local.tags
+
+  metric_query {
+    id = "running"
+    return_data = false
+
+    metric {
+      namespace   = "ECS/ContainerInsights"
+      metric_name = "RunningTaskCount"
+      period      = 60
+      stat        = "Average"
+
+      dimensions = {
+        ClusterName = var.cluster_name
+        ServiceName = var.service_name
+      }
+    }
+  }
+
+  metric_query {
+    id = "desired"
+    return_data = false
+
+    metric {
+      namespace   = "ECS/ContainerInsights"
+      metric_name = "DesiredTaskCount"
+      period      = 60
+      stat        = "Average"
+
+      dimensions = {
+        ClusterName = var.cluster_name
+        ServiceName = var.service_name
+      }
+    }
+  }
+
+  metric_query {
+    id          = "diff"
+    expression  = "running - desired"
+    label       = "Running minus Desired"
+    return_data = true
+  }
 }
 
-resource "aws_cloudwatch_metric_alarm" "ecs_high_cpu_critical" {
-  count = var.enable_service_count_alarm && local.service_exists ? 1 : 0
+resource "aws_cloudwatch_metric_alarm" "ecs_high_cpu" {
+  count = var.enable_alarms && local.service_exists ? 1 : 0
 
   alarm_name        = "ecs-high-cpu-${var.service_name}"
-  alarm_description = "ECS CPU > 75% for ${var.service_name} — potential scaling failure"
+  alarm_description = "ECS CPU > ${var.cpu_alarm_threshold}% for ${var.service_name} — autoscaling may not be keeping up"
 
   comparison_operator = "GreaterThanThreshold"
-  threshold           = 75
+  threshold           = var.cpu_alarm_threshold
   evaluation_periods  = 5
+  datapoints_to_alarm = 3
   period              = 60
   statistic           = "Average"
   treat_missing_data  = "notBreaching"
 
-  namespace   = "ECS/ContainerInsights"
-  metric_name = "CpuUtilized"
-
-  dimensions = {
-    ClusterName = data.aws_ecs_cluster.this.cluster_name
-    ServiceName = var.service_name
-  }
+  namespace   = "AWS/ECS"
+  metric_name = "CPUUtilization"
 
   alarm_actions = var.sns_topic_arns
   ok_actions    = var.sns_topic_arns
+
+  dimensions = {
+    ClusterName = var.cluster_name
+    ServiceName = var.service_name
+  }
+
+  tags = local.tags
 }

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -228,8 +228,8 @@ variable "has_autoscaler" {
   default     = true
 }
 
-variable "enable_service_count_alarm" {
-  description = "Whether to create a CloudWatch alarm for the service that alarms when there are no running tasks for the service. Defaults to `true`."
+variable "enable_alarms" {
+  description = "Whether to enable CloudWatch alarms for the service. Defaults to `true`."
   type        = bool
   default     = true
 }
@@ -238,4 +238,9 @@ variable "sns_topic_arns" {
   description = "List of SNS topic ARNs for alarm notifications"
   type        = list(string)
   default     = []
+}
+
+variable "cpu_alarm_threshold" {
+  type        = number
+  description = "CPU % at which to alarm — should be ~25% above autoscaling target"
 }


### PR DESCRIPTION
### Jira link

[HMRC-1842](https://transformuk.atlassian.net/browse/HMRC-1842)

### What?

I have added/removed/altered:

- [x] Added ecs_task_flapping CloudWatch alarm to detect rapid ECS task restarts.
- [x] Added ecs_high_cpu_critical alarm to alert when CPU remains above 80% for sustained periods.

### Why?

I am doing this because:

- During the 18/12 outage, ECS tasks were repeatedly killed and re‑provisioned without triggering an alert.
The new flapping alarm provides early detection of unstable ECS services.
- CPU was pegged at ~74% but auto-scaling did not activate quickly enough.
The high‑CPU alarm notifies us when services are at risk of degradation despite appearing “healthy.”

### Have you? (optional)

- [ ] Reviewed infrastructure changes with stakeholders
- [ ] Considered downstream users of the infrastructure
- [ ] Thought of ways to reduce down time

### Deployment risks (optional)

- This change could bring down our developer flows and cause disruption
- The core application uses these resources
