### PR TITLE
Remove AmazonECS_FullAccess from ECS task role; use task_role_policy_arns for least privilege

### DIFF
--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -32,7 +32,6 @@ No modules.
 | [aws_iam_role_policy_attachment.execution_role_additional_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.execution_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.task_role_additional_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.task_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_service_discovery_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_service) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |

--- a/aws/ecs-service/iam.tf
+++ b/aws/ecs-service/iam.tf
@@ -28,14 +28,13 @@ resource "aws_iam_role_policy_attachment" "execution_role_additional_policies" {
   policy_arn = var.execution_role_policy_arns[count.index]
 }
 
+# Task role: used by the application running inside the ECS task (not by ECS control plane).
+# This module does not attach any default managed policy. Callers must grant least-privilege
+# permissions via var.task_role_policy_arns (e.g. scoped policies for S3, Secrets Manager,
+# SQS, RDS, or other services the task needs). Do not use AWS managed full-access policies.
 resource "aws_iam_role" "task_role" {
   name               = "${var.service_name}-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume_role_policy.json
-}
-
-resource "aws_iam_role_policy_attachment" "task_role_policy" {
-  role       = aws_iam_role.task_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonECS_FullAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "task_role_additional_policies" {


### PR DESCRIPTION
### Jira link

[HMRC-1998](https://transformuk.atlassian.net/browse/HMRC-1998)

Fix IAM least privilege (security finding 8.6.1)

- Change: Removed the AmazonECS_FullAccess managed policy from the ECS task role in aws/ecs-service/iam.tf. The task role no longer has any default permissions.
- Reason: The task role is for the app running inside the task (web/job/migrations), not the ECS control plane. Granting ECS full access from the task violated least privilege.
