### PR TITLE
AI-1964: Add explicit ECS target group mappings

### DIFF
--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -78,7 +78,7 @@ No modules.
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs to place the service into. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to all resources in this module. | `map(string)` | `{}` | no |
 | <a name="input_target_group_arn"></a> [target\_group\_arn](#input\_target\_group\_arn) | ARN of the load balancer target group. | `string` | `null` | no |
-| <a name="input_target_group_arns"></a> [target\_group\_arns](#input\_target\_group\_arns) | ARNs of the load balancer target groups. Takes precedence over `target_group_arn` when set. | `list(string)` | `[]` | no |
+| <a name="input_target_group_mappings"></a> [target\_group\_mappings](#input\_target\_group\_mappings) | Explicit load balancer target group to container port mappings. Takes precedence over `target_group_arn` when set. | <pre>list(object({<br/>    target_group_arn = string<br/>    container_port   = number<br/>  }))</pre> | `[]` | no |
 | <a name="input_task_role_policy_arns"></a> [task\_role\_policy\_arns](#input\_task\_role\_policy\_arns) | A list of additional policy ARNs to attach to the service's task role. | `list(string)` | `[]` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Timeout time for the ECS service to become stable before producing a Terraform error. | `string` | `"15m"` | no |
 | <a name="input_wait_for_steady_state"></a> [wait\_for\_steady\_state](#input\_wait\_for\_steady\_state) | Whether to wait for the service to become stable akin to `aws ecs wait services-stable`. Defaults to true. | `bool` | `true` | no |

--- a/aws/ecs-service/locals.tf
+++ b/aws/ecs-service/locals.tf
@@ -12,7 +12,16 @@ locals {
 
   service_exists = var.container_definition_kind != "job"
 
-  target_group_arns = length(var.target_group_arns) > 0 ? var.target_group_arns : var.target_group_arn != null ? [var.target_group_arn] : []
+  container_ports = distinct(length(var.target_group_mappings) > 0 ? [
+    for mapping in var.target_group_mappings : mapping.container_port
+  ] : [var.container_port])
+
+  target_group_port_mappings = length(var.target_group_mappings) > 0 ? var.target_group_mappings : var.target_group_arn != null ? [
+    {
+      target_group_arn = var.target_group_arn
+      container_port   = var.container_port
+    }
+  ] : []
 
   container_definition_kinds = {
     "web"       = local.container_definition
@@ -48,10 +57,12 @@ locals {
       entryPoint  = var.container_entrypoint
       command     = var.container_command
 
-      portMappings = [{
-        protocol      = "tcp"
-        containerPort = var.container_port
-      }]
+      portMappings = [
+        for port in local.container_ports : {
+          protocol      = "tcp"
+          containerPort = port
+        }
+      ]
 
       logConfiguration = {
         logDriver = "awslogs"
@@ -78,10 +89,12 @@ locals {
     entryPoint  = var.container_entrypoint
     command     = var.container_command
 
-    portMappings = [{
-      protocol      = "tcp"
-      containerPort = var.container_port
-    }]
+    portMappings = [
+      for port in local.container_ports : {
+        protocol      = "tcp"
+        containerPort = port
+      }
+    ]
 
     logConfiguration = {
       logDriver = "awslogs"

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -12,11 +12,11 @@ resource "aws_ecs_service" "this" {
   enable_execute_command = var.enable_ecs_exec
 
   dynamic "load_balancer" {
-    for_each = local.target_group_arns
+    for_each = local.target_group_port_mappings
     content {
       container_name   = var.service_name
-      container_port   = var.container_port
-      target_group_arn = load_balancer.value
+      container_port   = load_balancer.value.container_port
+      target_group_arn = load_balancer.value.target_group_arn
     }
   }
 

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -129,10 +129,13 @@ variable "target_group_arn" {
   default     = null
 }
 
-variable "target_group_arns" {
-  description = "ARNs of the load balancer target groups. Takes precedence over `target_group_arn` when set."
-  type        = list(string)
-  default     = []
+variable "target_group_mappings" {
+  description = "Explicit load balancer target group to container port mappings. Takes precedence over `target_group_arn` when set."
+  type = list(object({
+    target_group_arn = string
+    container_port   = number
+  }))
+  default = []
 }
 
 variable "security_groups" {


### PR DESCRIPTION
### Jira link

[AI-1964](https://transformuk.atlassian.net/browse/AI-1964)

### What?

- [x] Replace the ECS service module's `target_group_arns` input with explicit `target_group_mappings`
- [x] Allow each target group mapping to declare the container port it should register against
- [x] Keep the legacy single `target_group_arn` and `container_port` path for compatibility
- [x] Update ECS task port mappings and module docs to match the new API

### Why?

This removes the positional coupling between target groups and ports so services can expose multiple ports, including 8080 and 8443 during the TLS migration, without relying on implicit ordering.