### PR TITLE
BAU: Fix typo in CloudWatch alarm configuration

### DIFF
--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -159,7 +159,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_capacity_loss" {
   evaluation_periods  = 5
   datapoints_to_alarm = 3
 
-  treat_missing_data = "Breaching"
+  treat_missing_data = "breaching"
 
   alarm_actions = var.sns_topic_arns
   ok_actions    = var.sns_topic_arns


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Fixed typo in the `ecs_capacity_loss` CW alarm, changed treat_missing_data from "Breaching" to "breaching"

### Why?

I am doing this because:

- The value Breaching is not supported for TreatMissingData parameter. Supported values are [breaching, notBreaching, ignore, missing].

### Have you? (optional)

- [ ] Reviewed infrastructure changes with stakeholders
- [ ] Considered downstream users of the infrastructure
- [ ] Thought of ways to reduce down time

### Deployment risks (optional)

- This change could bring down our developer flows and cause disruption
- The core application uses these resources
