### PR TITLE
Fix: Guard ECS high CPU alarm when cpu_alarm_threshold is null

### DIFF
--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -228,7 +228,11 @@ resource "aws_cloudwatch_metric_alarm" "ecs_capacity_loss" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ecs_high_cpu" {
-  count = var.enable_alarms && local.service_exists ? 1 : 0
+  count = (
+    var.enable_alarms &&
+    local.service_exists &&
+    var.cpu_alarm_threshold != null
+  ) ? 1 : 0
 
   alarm_name        = "ecs-high-cpu-${var.service_name}"
   alarm_description = "ECS CPU > ${var.cpu_alarm_threshold}% for ${var.service_name} — autoscaling may not be keeping up"


### PR DESCRIPTION
### Jira link

N/A

### What?

I have added/removed/altered:

- [x] Update the `ecs_high_cpu` alarm resource to only create the high CPU CloudWatch alarm when `cpu_alarm_threshold `is explicitly provided.

### Why?

I am doing this because:

- cpu_alarm_threshold is a nullable variable, but was previously referenced unconditionally in alarm definitions. When unset, this caused Terraform failures due to string interpolation errors. Guarding the alarm resource ensures safe defaults, avoids deployment failures, and aligns module behaviour with Terraform’s null‑handling semantics.

### Have you? (optional)

- [ ] Reviewed infrastructure changes with stakeholders
- [ ] Considered downstream users of the infrastructure
- [ ] Thought of ways to reduce down time

### Deployment risks (optional)

- This change could bring down our developer flows and cause disruption
- The core application uses these resources
