### PR TITLE
HMRC-2248: Add observability sns topic variable for lower-urgency alarms

### DIFF
--- a/aws/ecs-service/locals.tf
+++ b/aws/ecs-service/locals.tf
@@ -73,4 +73,6 @@ locals {
   }]
 
   autoscaling_metrics = var.has_autoscaler ? var.autoscaling_metrics : {}
+
+  observability_topic_arns = coalesce(var.observability_sns_topic_arns, var.sns_topic_arns)
 }

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -180,8 +180,8 @@ resource "aws_cloudwatch_metric_alarm" "ecs_capacity_loss" {
 
   treat_missing_data = "breaching"
 
-  alarm_actions = var.sns_topic_arns
-  ok_actions    = var.sns_topic_arns
+  alarm_actions = local.observability_topic_arns
+  ok_actions    = local.observability_topic_arns
 
   tags = local.tags
 
@@ -248,8 +248,8 @@ resource "aws_cloudwatch_metric_alarm" "ecs_high_cpu" {
   namespace   = "AWS/ECS"
   metric_name = "CPUUtilization"
 
-  alarm_actions = var.sns_topic_arns
-  ok_actions    = var.sns_topic_arns
+  alarm_actions = local.observability_topic_arns
+  ok_actions    = local.observability_topic_arns
 
   dimensions = {
     ClusterName = var.cluster_name

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -265,6 +265,12 @@ variable "sns_topic_arns" {
   default     = []
 }
 
+variable "observability_sns_topic_arns" {
+  description = "SNS topic ARNs for lower-urgency observability alarms (capacity loss, high CPU)"
+  type        = list(string)
+  default     = null
+}
+
 variable "cpu_alarm_threshold" {
   type        = number
   description = "CPU % at which to alarm — should be ~25% above autoscaling target"


### PR DESCRIPTION
### Jira link

[HMRC-2248](https://transformuk.atlassian.net/browse/HMRC-2248)

### What?

I have added/removed/altered:

- [x] Added an optional `observability_sns_topic_arns` variable to the ECS service module. When provided, `ecs_capacity_loss` and `ecs_high_cpu` alarms route to this topic instead of `sns_topic_arns`. Falls back to `sns_topic_arns` via `coalesce` if not set `service_count` continues to use `sns_topic_arns` unchanged.

### Why?
I am doing this because:

- Allows callers to split alarm routing by urgency without requiring changes to every existing module consumer. Backwards compatible - existing callers with no `observability_sns_topic_arns` are unaffected.

## Risk
🟢 **Green** — existing behaviour is fully preserved via null default and coalesce fallback. No caller is broken unless they explicitly pass the new variable.

### Have you? (optional)

- [ ] Reviewed infrastructure changes with stakeholders
- [ ] Considered downstream users of the infrastructure
- [ ] Thought of ways to reduce down time

### Deployment risks (optional)

- This change could bring down our developer flows and cause disruption
- The core application uses these resources
