### PR TITLE
HMRC-2405: Increase ECS alarm evaluation windows

### DIFF
--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -175,8 +175,8 @@ resource "aws_cloudwatch_metric_alarm" "ecs_capacity_loss" {
 
   comparison_operator = "LessThanThreshold"
   threshold           = 0
-  evaluation_periods  = 5
-  datapoints_to_alarm = 3
+  evaluation_periods  = 10
+  datapoints_to_alarm = 8
 
   treat_missing_data = "breaching"
 
@@ -239,8 +239,8 @@ resource "aws_cloudwatch_metric_alarm" "ecs_high_cpu" {
 
   comparison_operator = "GreaterThanThreshold"
   threshold           = var.cpu_alarm_threshold
-  evaluation_periods  = 5
-  datapoints_to_alarm = 3
+  evaluation_periods  = 10
+  datapoints_to_alarm = 8
   period              = 60
   statistic           = "Average"
   treat_missing_data  = "notBreaching"


### PR DESCRIPTION
### Jira link

[HMRC-2405](https://transformuk.atlassian.net/browse/HMRC-2405)

### What?

I have added/removed/altered:

- Increased ECS alarm evaluation windows to reduce false positives before routing alerts to production.

### Why?

- The previous configs were prone to triggering during normal deployment activity and autoscaling recovery periods, creating noise and reducing confidence in production alerts.
- The updated configs provide additional time for ECS deployments and autoscaling actions to converge before an alarm is raised, making alerts more actionable.

### Risk 
Risk level: 🟢

This change only modifies CloudWatch alarm sensitivity and does not affect service behaviour, scaling configuration, or application traffic. The primary risk is slightly slower detection of genuine capacity or CPU pressure events in exchange for fewer false-positive alerts.
