### PR TITLE
HMRC-2405: Allow ECS capacity loss alarm SNS routing override

### DIFF
--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -69,9 +69,8 @@ No modules.
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | A maximum capacity for autoscaling. | `number` | n/a | yes |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory limits for container. | `number` | `512` | no |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | A minimum capacity for autoscaling. Defaults to 1. | `number` | `1` | no |
-| <a name="input_observability_topic_arns"></a> [observability\_topic\_arns](#input\_observability\_topic\_arns) | SNS topic ARNs for lower-urgency observability alarms (capacity loss, high CPU) | `list(string)` | n/a | yes |
+| <a name="input_observability_sns_topic_arns"></a> [observability\_sns\_topic\_arns](#input\_observability\_sns\_topic\_arns) | SNS topic ARNs for lower-urgency observability alarms (high CPU) | `list(string)` | `null` | no |
 | <a name="input_private_dns_namespace"></a> [private\_dns\_namespace](#input\_private\_dns\_namespace) | Private DNS namespace name. If provided, enables service discovery. | `string` | `null` | no |
-| <a name="input_prod_topic_arns"></a> [prod\_topic\_arns](#input\_prod\_topic\_arns) | List of SNS topic ARNs for alarm notifications | `list(string)` | `[]` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region. | `string` | n/a | yes |
 | <a name="input_scale_in_cooldown"></a> [scale\_in\_cooldown](#input\_scale\_in\_cooldown) | Prevents aggressive scale-in by enforcing a waiting period after tasks are removed. | `number` | `300` | no |
 | <a name="input_scale_out_cooldown"></a> [scale\_out\_cooldown](#input\_scale\_out\_cooldown) | Minimum time to wait after a scale-out before allowing another scale-out, giving new tasks time to start contributing capacity. | `number` | `60` | no |
@@ -83,6 +82,7 @@ No modules.
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service to create. | `string` | n/a | yes |
 | <a name="input_service_secrets_config"></a> [service\_secrets\_config](#input\_service\_secrets\_config) | Service specific environment secrets | `list(map(string))` | `[]` | no |
 | <a name="input_skip_destroy"></a> [skip\_destroy](#input\_skip\_destroy) | (Optional) Whether to retain the old revision when the resource is destroyed or replacement is necessary. Default is false. | `bool` | `false` | no |
+| <a name="input_sns_topic_arns"></a> [sns\_topic\_arns](#input\_sns\_topic\_arns) | List of SNS topic ARNs for alarm notifications | `list(string)` | `[]` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs to place the service into. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to all resources in this module. | `map(string)` | `{}` | no |
 | <a name="input_target_group_arn"></a> [target\_group\_arn](#input\_target\_group\_arn) | ARN of the load balancer target group. | `string` | `null` | no |

--- a/aws/ecs-service/README.md
+++ b/aws/ecs-service/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5 |
 
 ## Modules
 
@@ -60,6 +60,7 @@ No modules.
 | <a name="input_deployment_minimum_healthy_percent"></a> [deployment\_minimum\_healthy\_percent](#input\_deployment\_minimum\_healthy\_percent) | Minimum healthy percentage for a deployment. Defaults to 100 for zero downtime deploys. | `number` | `100` | no |
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Base docker image to use. | `string` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Tag of the docker image to use. | `string` | n/a | yes |
+| <a name="input_ecs_capacity_loss_topic_arns"></a> [ecs\_capacity\_loss\_topic\_arns](#input\_ecs\_capacity\_loss\_topic\_arns) | SNS topic ARNs for ECS capacity loss alarms | `list(string)` | `null` | no |
 | <a name="input_enable_alarms"></a> [enable\_alarms](#input\_enable\_alarms) | Whether to enable CloudWatch alarms for the service. Defaults to `true`. | `bool` | `true` | no |
 | <a name="input_enable_ecs_exec"></a> [enable\_ecs\_exec](#input\_enable\_ecs\_exec) | Whether to enable AWS ECS Exec for the task. Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_enable_rollback"></a> [enable\_rollback](#input\_enable\_rollback) | Whether to enable circuit breaker rollbacks. Defaults to `true`. | `bool` | `true` | no |
@@ -68,7 +69,9 @@ No modules.
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | A maximum capacity for autoscaling. | `number` | n/a | yes |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory limits for container. | `number` | `512` | no |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | A minimum capacity for autoscaling. Defaults to 1. | `number` | `1` | no |
+| <a name="input_observability_topic_arns"></a> [observability\_topic\_arns](#input\_observability\_topic\_arns) | SNS topic ARNs for lower-urgency observability alarms (capacity loss, high CPU) | `list(string)` | n/a | yes |
 | <a name="input_private_dns_namespace"></a> [private\_dns\_namespace](#input\_private\_dns\_namespace) | Private DNS namespace name. If provided, enables service discovery. | `string` | `null` | no |
+| <a name="input_prod_topic_arns"></a> [prod\_topic\_arns](#input\_prod\_topic\_arns) | List of SNS topic ARNs for alarm notifications | `list(string)` | `[]` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region. | `string` | n/a | yes |
 | <a name="input_scale_in_cooldown"></a> [scale\_in\_cooldown](#input\_scale\_in\_cooldown) | Prevents aggressive scale-in by enforcing a waiting period after tasks are removed. | `number` | `300` | no |
 | <a name="input_scale_out_cooldown"></a> [scale\_out\_cooldown](#input\_scale\_out\_cooldown) | Minimum time to wait after a scale-out before allowing another scale-out, giving new tasks time to start contributing capacity. | `number` | `60` | no |
@@ -80,7 +83,6 @@ No modules.
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service to create. | `string` | n/a | yes |
 | <a name="input_service_secrets_config"></a> [service\_secrets\_config](#input\_service\_secrets\_config) | Service specific environment secrets | `list(map(string))` | `[]` | no |
 | <a name="input_skip_destroy"></a> [skip\_destroy](#input\_skip\_destroy) | (Optional) Whether to retain the old revision when the resource is destroyed or replacement is necessary. Default is false. | `bool` | `false` | no |
-| <a name="input_sns_topic_arns"></a> [sns\_topic\_arns](#input\_sns\_topic\_arns) | List of SNS topic ARNs for alarm notifications | `list(string)` | `[]` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs to place the service into. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to all resources in this module. | `map(string)` | `{}` | no |
 | <a name="input_target_group_arn"></a> [target\_group\_arn](#input\_target\_group\_arn) | ARN of the load balancer target group. | `string` | `null` | no |

--- a/aws/ecs-service/locals.tf
+++ b/aws/ecs-service/locals.tf
@@ -74,5 +74,7 @@ locals {
 
   autoscaling_metrics = var.has_autoscaler ? var.autoscaling_metrics : {}
 
-  observability_topic_arns = coalesce(var.observability_sns_topic_arns, var.sns_topic_arns)
+
+  ecs_capacity_loss_topic_arns = coalesce(var.ecs_capacity_loss_topic_arns, var.sns_topic_arns)
+
 }

--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -180,8 +180,8 @@ resource "aws_cloudwatch_metric_alarm" "ecs_capacity_loss" {
 
   treat_missing_data = "breaching"
 
-  alarm_actions = local.observability_topic_arns
-  ok_actions    = local.observability_topic_arns
+  alarm_actions = local.ecs_capacity_loss_topic_arns
+  ok_actions    = local.ecs_capacity_loss_topic_arns
 
   tags = local.tags
 
@@ -248,8 +248,8 @@ resource "aws_cloudwatch_metric_alarm" "ecs_high_cpu" {
   namespace   = "AWS/ECS"
   metric_name = "CPUUtilization"
 
-  alarm_actions = local.observability_topic_arns
-  ok_actions    = local.observability_topic_arns
+  alarm_actions = var.observability_sns_topic_arns
+  ok_actions    = var.observability_sns_topic_arns
 
   dimensions = {
     ClusterName = var.cluster_name

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -271,6 +271,12 @@ variable "observability_sns_topic_arns" {
   default     = null
 }
 
+variable "ecs_capacity_loss_topic_arns" {
+  description = "SNS topic ARNs for ECS capacity loss alarms"
+  type        = list(string)
+  default     = null
+}
+
 variable "cpu_alarm_threshold" {
   type        = number
   description = "CPU % at which to alarm — should be ~25% above autoscaling target"

--- a/aws/ecs-service/variables.tf
+++ b/aws/ecs-service/variables.tf
@@ -266,7 +266,7 @@ variable "sns_topic_arns" {
 }
 
 variable "observability_sns_topic_arns" {
-  description = "SNS topic ARNs for lower-urgency observability alarms (capacity loss, high CPU)"
+  description = "SNS topic ARNs for lower-urgency observability alarms (high CPU)"
   type        = list(string)
   default     = null
 }


### PR DESCRIPTION
### Jira link

[HMRC-2405](https://transformuk.atlassian.net/browse/HMRC-2405)

### What?

- Added optional `ecs_capacity_loss_topic_arns` variable.
- Updated the ECS capacity loss alarm to use a dedicated SNS topic configuration when provided.
- Defaulted ECS capacity loss notifications to `prod_topic_arns` to maintain existing behaviour.

### Why?

I am doing this because:

- The ECS capacity loss alarm is considered a service health signal and should be visible in the production alert channel following recent [evaluation period changes](https://github.com/trade-tariff/trade-tariff-platform-terraform-modules/pull/101).
- Using a dedicated routing variable makes future routing changes straightforward and avoids child module modifications.

### Risk:
Risk level: 🟢

- Only affects CloudWatch alarm notification routing.
- No infrastructure, service, or deployment behaviour changes.
- Alarm delivery will continue through existing SNS topics.
