### PR TITLE
HMRC-2587: Remove OK notifications from ECS high CPU alarms

### DIFF
--- a/aws/ecs-service/main.tf
+++ b/aws/ecs-service/main.tf
@@ -249,7 +249,6 @@ resource "aws_cloudwatch_metric_alarm" "ecs_high_cpu" {
   metric_name = "CPUUtilization"
 
   alarm_actions = var.observability_sns_topic_arns
-  ok_actions    = var.observability_sns_topic_arns
 
   dimensions = {
     ClusterName = var.cluster_name


### PR DESCRIPTION
### Jira link

[HMRC-2587](https://transformuk.atlassian.net/browse/HMRC-2587)

### What?
Removed `ok_actions` from the `ecs_high_cpu` CloudWatch alarm.
Availability-related alarms (`service_count` and `ecs_capacity_loss`) retain recovery notifications as the recovery signal provides useful operational context.

### Why?
`ecs_high_cpu` is an observability alert that can naturally fluctuate around its threshold and often self-resolves. Sending OK notifications to the same channel creates unnecessary noise and contributes to alert fatigue without providing actionable information.

This aligns with the notification guidelines to avoid notifying on conditions that self-resolve before intervention is required.

Risk Level

Low

- No impact to alarm detection or alerting.
- Alarm notifications continue to be sent when the alarm enters the ALARM state.
- Only recovery (OK) notifications are removed.
- No infrastructure or application behaviour changes.