### PR TITLE
Remove @github-copilot from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @trade-tariff/trade-tariff-platform @github-copilot
+*  @trade-tariff/trade-tariff-platform


### PR DESCRIPTION
### Jira link

HMRC-2630 (https://transformuk.atlassian.net/browse/HMRC-2630)

### What?

I have added/removed/altered:

- [x] Removed the invalid `@github-copilot` entry from CODEOWNERS

### Why?

I am doing this because:

- GitHub does not validate `@github-copilot` as a CODEOWNER and reports it as an unknown owner
- Copilot Code Review is already enabled at the organisation level with active review rulesets, so CODEOWNERS is not how Copilot reviews are configured
- Removing the invalid entry avoids "unknown owner" warnings without needing to grant `@github-copilot` write access

### Have you? (optional)

- [x] Reviewed infrastructure changes with stakeholders
- [x] Considered downstream users of the infrastructure
- [x] Thought of ways to reduce down time

### Deployment risks (optional)

- None — text-only change to an ownership metadata file, no infrastructure or resource changes.
