### PR TITLE
Add trade-tariff-admin team to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @trade-tariff/trade-tariff-platform
+*  @trade-tariff/trade-tariff-platform @trade-tariff/trade-tariff-admin


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added trade-tariff-admin as a code owner in CODEOWNERS

### Why?

I am doing this because:

- The trade-tariff-admin team should be a required reviewer across this repo, consistent with the platform team already listed

### Have you? (optional)

- [x] Reviewed infrastructure changes with stakeholders

### Deployment risks (optional)

- None — this only changes GitHub review routing, not deployed infrastructure
